### PR TITLE
Fix user repository implementation

### DIFF
--- a/app/src/test/java/br/com/sommelier/data/UserRepositoryImplTest.kt
+++ b/app/src/test/java/br/com/sommelier/data/UserRepositoryImplTest.kt
@@ -14,7 +14,7 @@ import com.google.firebase.firestore.CollectionReference
 import com.google.firebase.firestore.DocumentReference
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.QuerySnapshot
-import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -39,15 +39,19 @@ class UserRepositoryImplTest {
     @Test
     fun `GIVEN a successful task WHEN call saveUser THEN must return Unit`() = runTest {
         val unsuccessfulTask = mockk<Task<DocumentReference>>().apply {
-            coEvery { isSuccessful } returns true
+            every { isSuccessful } returns true
+            every { isComplete } returns true
+            every { isCanceled } returns false
+            every { exception } returns null
+            every { result } returns mockk()
         }
 
-        coEvery { usersCollectionMock.add(any()) } returns unsuccessfulTask
+        every { usersCollectionMock.add(any()) } returns unsuccessfulTask
 
         val result = userRepository.saveUser(dummyUserDomain)
 
-        assertTrue(result.isRight { problem ->
-            problem == Unit
+        assertTrue(result.isRight {
+            it == Unit
         })
     }
 
@@ -56,11 +60,14 @@ class UserRepositoryImplTest {
         runTest {
             val errorMessage = "Error writing document"
             val unsuccessfulTask = mockk<Task<DocumentReference>>().apply {
-                coEvery { isSuccessful } returns false
-                coEvery { exception?.message } returns errorMessage
+                every { isSuccessful } returns false
+                every { isComplete } returns true
+                every { isCanceled } returns false
+                every { exception?.message } returns errorMessage
+                every { result } returns mockk()
             }
 
-            coEvery { usersCollectionMock.add(any()) } returns unsuccessfulTask
+            every { usersCollectionMock.add(any()) } returns unsuccessfulTask
 
             val result = userRepository.saveUser(dummyUserDomain)
 
@@ -74,11 +81,14 @@ class UserRepositoryImplTest {
         runTest {
             val errorMessage = "An unknown problem occurred"
             val unsuccessfulTask = mockk<Task<DocumentReference>>().apply {
-                coEvery { isSuccessful } returns false
-                coEvery { exception?.message } returns null
+                every { isSuccessful } returns false
+                every { isComplete } returns true
+                every { isCanceled } returns false
+                every { exception?.message } returns null
+                every { result } returns mockk()
             }
 
-            coEvery { usersCollectionMock.add(any()) } returns unsuccessfulTask
+            every { usersCollectionMock.add(any()) } returns unsuccessfulTask
 
             val result = userRepository.saveUser(dummyUserDomain)
 
@@ -91,14 +101,17 @@ class UserRepositoryImplTest {
     fun `GIVEN a successful task WHEN call getUser THEN must return the expected userDomain`() =
         runTest {
             val successfulTask = mockk<Task<QuerySnapshot>>().apply {
-                coEvery { isSuccessful } returns true
-                coEvery { result.documents.isEmpty() } returns false
-                coEvery {
+                every { isSuccessful } returns true
+                every { isComplete } returns true
+                every { isCanceled } returns false
+                every { exception } returns null
+                every { result.documents.isEmpty() } returns false
+                every {
                     result.documents.firstOrNull()?.toObject(UserData::class.java)
                 } returns dummyUserData
             }
 
-            coEvery {
+            every {
                 usersCollectionMock.whereEqualTo(UID_FIELD, dummyUid).get()
             } returns successfulTask
 
@@ -113,11 +126,14 @@ class UserRepositoryImplTest {
     fun `GIVEN a successful task but with a empty documents list WHEN call getUser THEN must return the expected Problem`() =
         runTest {
             val successfulTask = mockk<Task<QuerySnapshot>>().apply {
-                coEvery { isSuccessful } returns true
-                coEvery { result.documents.isEmpty() } returns true
+                every { isSuccessful } returns true
+                every { isComplete } returns true
+                every { isCanceled } returns false
+                every { exception } returns null
+                every { result.documents.isEmpty() } returns true
             }
 
-            coEvery {
+            every {
                 usersCollectionMock.whereEqualTo(UID_FIELD, dummyUid).get()
             } returns successfulTask
 
@@ -133,11 +149,14 @@ class UserRepositoryImplTest {
         runTest {
             val errorMessage = "Error getting document"
             val unsuccessfulTask = mockk<Task<QuerySnapshot>>().apply {
-                coEvery { isSuccessful } returns false
-                coEvery { exception?.message } returns errorMessage
+                every { isSuccessful } returns false
+                every { isComplete } returns true
+                every { isCanceled } returns false
+                every { exception?.message } returns errorMessage
+                every { result } returns mockk()
             }
 
-            coEvery {
+            every {
                 usersCollectionMock.whereEqualTo(UID_FIELD, dummyUid).get()
             } returns unsuccessfulTask
 
@@ -153,11 +172,14 @@ class UserRepositoryImplTest {
         runTest {
             val errorMessage = "An unknown problem occurred"
             val unsuccessfulTask = mockk<Task<QuerySnapshot>>().apply {
-                coEvery { isSuccessful } returns false
-                coEvery { exception?.message } returns null
+                every { isSuccessful } returns false
+                every { isComplete } returns true
+                every { isCanceled } returns false
+                every { exception?.message } returns null
+                every { result } returns mockk()
             }
 
-            coEvery {
+            every {
                 usersCollectionMock.whereEqualTo(UID_FIELD, dummyUid).get()
             } returns unsuccessfulTask
 
@@ -172,33 +194,40 @@ class UserRepositoryImplTest {
     fun `GIVEN an successful task and a successful updateTask WHEN call updateUser THEN must return Unit`() =
         runTest {
             val dummyDocumentSnapshot = mockk<DocumentSnapshot>().apply {
-                coEvery { reference } returns mockk()
+                every { reference } returns mockk()
             }
 
             val successfulTask = mockk<Task<QuerySnapshot>>().apply {
-                coEvery { isSuccessful } returns true
-                coEvery { result.documents.isEmpty() } returns false
-                coEvery {
+                every { isSuccessful } returns true
+                every { isComplete } returns true
+                every { isCanceled } returns false
+                every { exception } returns null
+                every { result.documents.isEmpty() } returns false
+                every {
                     result.documents.firstOrNull()
                 } returns dummyDocumentSnapshot
             }
 
             val successfulUpdateTask = mockk<Task<Void>>().apply {
-                coEvery { isSuccessful } returns true
+                every { isSuccessful } returns true
+                every { isComplete } returns true
+                every { isCanceled } returns false
+                every { exception } returns null
+                every { result } returns mockk()
             }
 
-            coEvery {
+            every {
                 usersCollectionMock.whereEqualTo(UID_FIELD, dummyUserData.uid).get()
             } returns successfulTask
 
-            coEvery {
+            every {
                 dummyDocumentSnapshot.reference.set(any())
             } returns successfulUpdateTask
 
             val result = userRepository.updateUser(dummyUserDomain)
 
-            assertTrue(result.isRight { problem ->
-                problem == Unit
+            assertTrue(result.isRight {
+                it == Unit
             })
         }
 
@@ -206,28 +235,34 @@ class UserRepositoryImplTest {
     fun `GIVEN an successful task but an unsuccessful updateTask WHEN call updateUser THEN must return the expected Problem`() =
         runTest {
             val dummyDocumentSnapshot = mockk<DocumentSnapshot>().apply {
-                coEvery { reference } returns mockk()
+                every { reference } returns mockk()
             }
 
             val successfulTask = mockk<Task<QuerySnapshot>>().apply {
-                coEvery { isSuccessful } returns true
-                coEvery { result.documents.isEmpty() } returns false
-                coEvery {
+                every { isSuccessful } returns true
+                every { isComplete } returns true
+                every { isCanceled } returns false
+                every { exception } returns null
+                every { result.documents.isEmpty() } returns false
+                every {
                     result.documents.firstOrNull()
                 } returns dummyDocumentSnapshot
             }
 
             val errorMessage = "Error updating document"
             val unsuccessfulUpdateTask = mockk<Task<Void>>().apply {
-                coEvery { isSuccessful } returns false
-                coEvery { exception?.message } returns errorMessage
+                every { isSuccessful } returns false
+                every { isComplete } returns true
+                every { isCanceled } returns false
+                every { exception?.message } returns errorMessage
+                every { result } returns mockk()
             }
 
-            coEvery {
+            every {
                 usersCollectionMock.whereEqualTo(UID_FIELD, dummyUserData.uid).get()
             } returns successfulTask
 
-            coEvery {
+            every {
                 dummyDocumentSnapshot.reference.set(any())
             } returns unsuccessfulUpdateTask
 
@@ -242,11 +277,14 @@ class UserRepositoryImplTest {
     fun `GIVEN a successful task but with an empty documents list WHEN call updateUser THEN must return the expected Problem`() =
         runTest {
             val successfulTask = mockk<Task<QuerySnapshot>>().apply {
-                coEvery { isSuccessful } returns true
-                coEvery { result.documents.isEmpty() } returns true
+                every { isSuccessful } returns true
+                every { isComplete } returns true
+                every { isCanceled } returns false
+                every { exception } returns null
+                every { result.documents.isEmpty() } returns true
             }
 
-            coEvery {
+            every {
                 usersCollectionMock.whereEqualTo(UID_FIELD, dummyUserData.uid).get()
             } returns successfulTask
 
@@ -262,18 +300,21 @@ class UserRepositoryImplTest {
         runTest {
             val errorMessage = "Error updating document"
             val unsuccessfulTask = mockk<Task<QuerySnapshot>>().apply {
-                coEvery { isSuccessful } returns false
-                coEvery { exception?.message } returns errorMessage
+                every { isSuccessful } returns false
+                every { isComplete } returns true
+                every { isCanceled } returns false
+                every { exception?.message } returns errorMessage
+                every { result } returns mockk()
             }
 
-            coEvery {
+            every {
                 usersCollectionMock.whereEqualTo(UID_FIELD, dummyUserData.uid).get()
             } returns unsuccessfulTask
 
             val result = userRepository.updateUser(dummyUserDomain)
 
             assertTrue(result.isLeft { problem ->
-                problem is GetDocumentProblem && problem.message == errorMessage
+                problem is UpdateDocumentProblem && problem.message == errorMessage
             })
         }
 
@@ -282,18 +323,21 @@ class UserRepositoryImplTest {
         runTest {
             val errorMessage = "An unknown problem occurred"
             val unsuccessfulTask = mockk<Task<QuerySnapshot>>().apply {
-                coEvery { isSuccessful } returns false
-                coEvery { exception?.message } returns null
+                every { isSuccessful } returns false
+                every { isComplete } returns true
+                every { isCanceled } returns false
+                every { exception?.message } returns null
+                every { result } returns mockk()
             }
 
-            coEvery {
+            every {
                 usersCollectionMock.whereEqualTo(UID_FIELD, dummyUserData.uid).get()
             } returns unsuccessfulTask
 
             val result = userRepository.updateUser(dummyUserDomain)
 
             assertTrue(result.isLeft { problem ->
-                problem is GetDocumentProblem && problem.message == errorMessage
+                problem is UpdateDocumentProblem && problem.message == errorMessage
             })
         }
 
@@ -301,33 +345,40 @@ class UserRepositoryImplTest {
     fun `GIVEN an successful task and a successful deleteTask WHEN call deleteUser THEN must return Unit`() =
         runTest {
             val dummyDocumentSnapshot = mockk<DocumentSnapshot>().apply {
-                coEvery { reference } returns mockk()
+                every { reference } returns mockk()
             }
 
             val successfulTask = mockk<Task<QuerySnapshot>>().apply {
-                coEvery { isSuccessful } returns true
-                coEvery { result.documents.isEmpty() } returns false
-                coEvery {
+                every { isSuccessful } returns true
+                every { isComplete } returns true
+                every { isCanceled } returns false
+                every { exception } returns null
+                every { result.documents.isEmpty() } returns false
+                every {
                     result.documents.firstOrNull()
                 } returns dummyDocumentSnapshot
             }
 
             val successfulDeleteTask = mockk<Task<Void>>().apply {
-                coEvery { isSuccessful } returns true
+                every { isSuccessful } returns true
+                every { isComplete } returns true
+                every { isCanceled } returns false
+                every { exception } returns null
+                every { result } returns mockk()
             }
 
-            coEvery {
+            every {
                 usersCollectionMock.whereEqualTo(UID_FIELD, dummyUid).get()
             } returns successfulTask
 
-            coEvery {
+            every {
                 dummyDocumentSnapshot.reference.delete()
             } returns successfulDeleteTask
 
             val result = userRepository.deleteUser(dummyUid)
 
-            assertTrue(result.isRight { problem ->
-                problem == Unit
+            assertTrue(result.isRight {
+                it == Unit
             })
         }
 
@@ -335,28 +386,34 @@ class UserRepositoryImplTest {
     fun `GIVEN an successful task but an unsuccessful deleteTask WHEN call deleteUser THEN must return the expected Problem`() =
         runTest {
             val dummyDocumentSnapshot = mockk<DocumentSnapshot>().apply {
-                coEvery { reference } returns mockk()
+                every { reference } returns mockk()
             }
 
             val successfulTask = mockk<Task<QuerySnapshot>>().apply {
-                coEvery { isSuccessful } returns true
-                coEvery { result.documents.isEmpty() } returns false
-                coEvery {
+                every { isSuccessful } returns true
+                every { isComplete } returns true
+                every { isCanceled } returns false
+                every { exception } returns null
+                every { result.documents.isEmpty() } returns false
+                every {
                     result.documents.firstOrNull()
                 } returns dummyDocumentSnapshot
             }
 
             val errorMessage = "Error deleting document"
             val unsuccessfulDeleteTask = mockk<Task<Void>>().apply {
-                coEvery { isSuccessful } returns false
-                coEvery { exception?.message } returns errorMessage
+                every { isSuccessful } returns false
+                every { isComplete } returns true
+                every { isCanceled } returns false
+                every { exception?.message } returns errorMessage
+                every { result } returns mockk()
             }
 
-            coEvery {
+            every {
                 usersCollectionMock.whereEqualTo(UID_FIELD, dummyUid).get()
             } returns successfulTask
 
-            coEvery {
+            every {
                 dummyDocumentSnapshot.reference.delete()
             } returns unsuccessfulDeleteTask
 
@@ -371,11 +428,14 @@ class UserRepositoryImplTest {
     fun `GIVEN a successful task but with an empty documents list WHEN call deleteUser THEN must return the expected Problem`() =
         runTest {
             val successfulTask = mockk<Task<QuerySnapshot>>().apply {
-                coEvery { isSuccessful } returns true
-                coEvery { result.documents.isEmpty() } returns true
+                every { isSuccessful } returns true
+                every { isComplete } returns true
+                every { isCanceled } returns false
+                every { exception } returns null
+                every { result.documents.isEmpty() } returns true
             }
 
-            coEvery {
+            every {
                 usersCollectionMock.whereEqualTo(UID_FIELD, dummyUid).get()
             } returns successfulTask
 
@@ -391,18 +451,21 @@ class UserRepositoryImplTest {
         runTest {
             val errorMessage = "Error updating document"
             val unsuccessfulTask = mockk<Task<QuerySnapshot>>().apply {
-                coEvery { isSuccessful } returns false
-                coEvery { exception?.message } returns errorMessage
+                every { isSuccessful } returns false
+                every { isComplete } returns true
+                every { isCanceled } returns false
+                every { exception?.message } returns errorMessage
+                every { result } returns mockk()
             }
 
-            coEvery {
+            every {
                 usersCollectionMock.whereEqualTo(UID_FIELD, dummyUid).get()
             } returns unsuccessfulTask
 
             val result = userRepository.deleteUser(dummyUid)
 
             assertTrue(result.isLeft { problem ->
-                problem is GetDocumentProblem && problem.message == errorMessage
+                problem is DeleteDocumentProblem && problem.message == errorMessage
             })
         }
 
@@ -411,18 +474,21 @@ class UserRepositoryImplTest {
         runTest {
             val errorMessage = "An unknown problem occurred"
             val unsuccessfulTask = mockk<Task<QuerySnapshot>>().apply {
-                coEvery { isSuccessful } returns false
-                coEvery { exception?.message } returns null
+                every { isSuccessful } returns false
+                every { isComplete } returns true
+                every { isCanceled } returns false
+                every { exception?.message } returns null
+                every { result } returns mockk()
             }
 
-            coEvery {
+            every {
                 usersCollectionMock.whereEqualTo(UID_FIELD, dummyUid).get()
             } returns unsuccessfulTask
 
             val result = userRepository.deleteUser(dummyUid)
 
             assertTrue(result.isLeft { problem ->
-                problem is GetDocumentProblem && problem.message == errorMessage
+                problem is DeleteDocumentProblem && problem.message == errorMessage
             })
         }
 }


### PR DESCRIPTION
### This Pull Request includes
- [x] Bugfix

- [ ] New feature

- [ ] Refactor

### Summary
Fix `UserRepository` implementation using `await()` function

### Changes
- Fixed all `UserRepositoryImpl` functions replacing `withContext(Dispatchers.IO){ }` for calling `await()` after Firebase functions
- Added unit tests

### Related Issues
- This MR resolves the #4 issue

### Feature flags
N/A

### Impact
SommelierModule

### Tests
Unit tests

### Reviewers
- @ronaldocoding 

