### PR TITLE
Add user related use cases

### DIFF
--- a/app/src/main/java/br/com/sommelier/base/usecase/UseCase.kt
+++ b/app/src/main/java/br/com/sommelier/base/usecase/UseCase.kt
@@ -10,13 +10,13 @@ import br.com.sommelier.base.result.Success
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 
-abstract class UseCase<in P, R>(private val coroutinesDispatcher: CoroutineDispatcher) {
+abstract class UseCase<in P, R>(private val coroutineDispatcher: CoroutineDispatcher) {
 
     protected abstract suspend fun execute(parameters: P): Either<Problem, R>
 
     suspend operator fun invoke(parameters: P): Either<Failure, Success<R>> {
         return try {
-            withContext(coroutinesDispatcher) {
+            withContext(coroutineDispatcher) {
                 execute(parameters).let { result ->
                     when (result) {
                         is Either.Left -> Failure(result.value).left()

--- a/app/src/main/java/br/com/sommelier/di/SommelierModule.kt
+++ b/app/src/main/java/br/com/sommelier/di/SommelierModule.kt
@@ -48,7 +48,6 @@ object SommelierModule {
                 coroutineDispatcher = get()
             )
         }
-        factory { GetCurrentUserUseCase(authRepository = get(), coroutineDispatcher = get()) }
         factory {
             DeleteUserUseCase(
                 authRepository = get(),
@@ -56,9 +55,9 @@ object SommelierModule {
                 coroutineDispatcher = get()
             )
         }
+        factory { GetCurrentUserUseCase(authRepository = get(), coroutineDispatcher = get()) }
         factory { GetUserDocumentUseCase(userRepository = get(), coroutineDispatcher = get()) }
         factory { IsUserEmailVerifiedUseCase(authRepository = get(), coroutineDispatcher = get()) }
-        factory { SignInUserUseCase(authRepository = get(), coroutineDispatcher = get()) }
         factory { IsUserSignedInUseCase(authRepository = get(), coroutineDispatcher = get()) }
         factory { ReauthenticateUserUseCase(authRepository = get(), coroutineDispatcher = get()) }
         factory {
@@ -73,6 +72,7 @@ object SommelierModule {
                 coroutineDispatcher = get()
             )
         }
+        factory { SignInUserUseCase(authRepository = get(), coroutineDispatcher = get()) }
         factory { SignOutUserUseCase(authRepository = get(), coroutineDispatcher = get()) }
         factory { UpdateUserDocumentUseCase(userRepository = get(), coroutineDispatcher = get()) }
         factory {

--- a/app/src/main/java/br/com/sommelier/di/SommelierModule.kt
+++ b/app/src/main/java/br/com/sommelier/di/SommelierModule.kt
@@ -13,6 +13,7 @@ import br.com.sommelier.domain.usecase.SendEmailVerificationUseCase
 import br.com.sommelier.domain.usecase.SendPasswordResetEmailUseCase
 import br.com.sommelier.domain.usecase.SignInUserUseCase
 import br.com.sommelier.domain.usecase.SignOutUserUseCase
+import br.com.sommelier.domain.usecase.UpdateUserDocumentUseCase
 import br.com.sommelier.util.FirestoreCollections.USERS
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.ktx.auth
@@ -55,6 +56,7 @@ object SommelierModule {
             )
         }
         factory { SignOutUserUseCase(authRepository = get(), coroutineDispatcher = get()) }
+        factory { UpdateUserDocumentUseCase(userRepository = get(), coroutineDispatcher = get()) }
     }
 
     private fun provideFirebaseAuth(): FirebaseAuth {

--- a/app/src/main/java/br/com/sommelier/di/SommelierModule.kt
+++ b/app/src/main/java/br/com/sommelier/di/SommelierModule.kt
@@ -10,6 +10,7 @@ import br.com.sommelier.domain.usecase.IsUserEmailVerifiedUseCase
 import br.com.sommelier.domain.usecase.IsUserSignedInUseCase
 import br.com.sommelier.domain.usecase.ReauthenticateUserUseCase
 import br.com.sommelier.domain.usecase.SendEmailVerificationUseCase
+import br.com.sommelier.domain.usecase.SendPasswordResetEmailUseCase
 import br.com.sommelier.domain.usecase.SignInUserUseCase
 import br.com.sommelier.domain.usecase.SignOutUserUseCase
 import br.com.sommelier.util.FirestoreCollections.USERS
@@ -43,6 +44,12 @@ object SommelierModule {
         factory { ReauthenticateUserUseCase(authRepository = get(), coroutineDispatcher = get()) }
         factory {
             SendEmailVerificationUseCase(
+                authRepository = get(),
+                coroutineDispatcher = get()
+            )
+        }
+        factory {
+            SendPasswordResetEmailUseCase(
                 authRepository = get(),
                 coroutineDispatcher = get()
             )

--- a/app/src/main/java/br/com/sommelier/di/SommelierModule.kt
+++ b/app/src/main/java/br/com/sommelier/di/SommelierModule.kt
@@ -38,7 +38,7 @@ object SommelierModule {
     }
 
     private val domainModule = module {
-        factory { provideCoroutinesDispatcherIO() }
+        factory { provideCoroutineDispatcherIO() }
         factory {
             CreateUserUseCase(
                 authRepository = get(),
@@ -87,7 +87,7 @@ object SommelierModule {
         return Firebase.firestore
     }
 
-    private fun provideCoroutinesDispatcherIO(): CoroutineDispatcher {
+    private fun provideCoroutineDispatcherIO(): CoroutineDispatcher {
         return Dispatchers.IO
     }
 

--- a/app/src/main/java/br/com/sommelier/di/SommelierModule.kt
+++ b/app/src/main/java/br/com/sommelier/di/SommelierModule.kt
@@ -4,6 +4,7 @@ import br.com.sommelier.data.repository.AuthRepositoryImpl
 import br.com.sommelier.data.repository.UserRepositoryImpl
 import br.com.sommelier.domain.repository.AuthRepository
 import br.com.sommelier.domain.repository.UserRepository
+import br.com.sommelier.domain.usecase.CreateUserUseCase
 import br.com.sommelier.domain.usecase.GetCurrentUserUseCase
 import br.com.sommelier.domain.usecase.GetUserDocumentUseCase
 import br.com.sommelier.domain.usecase.IsUserEmailVerifiedUseCase
@@ -37,6 +38,13 @@ object SommelierModule {
 
     private val domainModule = module {
         factory { provideCoroutinesDispatcherIO() }
+        factory {
+            CreateUserUseCase(
+                authRepository = get(),
+                userRepository = get(),
+                coroutineDispatcher = get()
+            )
+        }
         factory { GetCurrentUserUseCase(authRepository = get(), coroutineDispatcher = get()) }
         factory { GetUserDocumentUseCase(userRepository = get(), coroutineDispatcher = get()) }
         factory { IsUserEmailVerifiedUseCase(authRepository = get(), coroutineDispatcher = get()) }

--- a/app/src/main/java/br/com/sommelier/di/SommelierModule.kt
+++ b/app/src/main/java/br/com/sommelier/di/SommelierModule.kt
@@ -17,6 +17,7 @@ import br.com.sommelier.domain.usecase.SignInUserUseCase
 import br.com.sommelier.domain.usecase.SignOutUserUseCase
 import br.com.sommelier.domain.usecase.UpdateUserDocumentUseCase
 import br.com.sommelier.domain.usecase.UpdateUserEmailUseCase
+import br.com.sommelier.domain.usecase.UpdateUserPasswordUseCase
 import br.com.sommelier.util.FirestoreCollections.USERS
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.ktx.auth
@@ -81,6 +82,7 @@ object SommelierModule {
                 coroutineDispatcher = get()
             )
         }
+        factory { UpdateUserPasswordUseCase(authRepository = get(), coroutineDispatcher = get()) }
     }
 
     private fun provideFirebaseAuth(): FirebaseAuth {

--- a/app/src/main/java/br/com/sommelier/di/SommelierModule.kt
+++ b/app/src/main/java/br/com/sommelier/di/SommelierModule.kt
@@ -5,6 +5,7 @@ import br.com.sommelier.data.repository.UserRepositoryImpl
 import br.com.sommelier.domain.repository.AuthRepository
 import br.com.sommelier.domain.repository.UserRepository
 import br.com.sommelier.domain.usecase.CreateUserUseCase
+import br.com.sommelier.domain.usecase.DeleteUserUseCase
 import br.com.sommelier.domain.usecase.GetCurrentUserUseCase
 import br.com.sommelier.domain.usecase.GetUserDocumentUseCase
 import br.com.sommelier.domain.usecase.IsUserEmailVerifiedUseCase
@@ -46,6 +47,13 @@ object SommelierModule {
             )
         }
         factory { GetCurrentUserUseCase(authRepository = get(), coroutineDispatcher = get()) }
+        factory {
+            DeleteUserUseCase(
+                authRepository = get(),
+                userRepository = get(),
+                coroutineDispatcher = get()
+            )
+        }
         factory { GetUserDocumentUseCase(userRepository = get(), coroutineDispatcher = get()) }
         factory { IsUserEmailVerifiedUseCase(authRepository = get(), coroutineDispatcher = get()) }
         factory { SignInUserUseCase(authRepository = get(), coroutineDispatcher = get()) }

--- a/app/src/main/java/br/com/sommelier/di/SommelierModule.kt
+++ b/app/src/main/java/br/com/sommelier/di/SommelierModule.kt
@@ -16,6 +16,7 @@ import br.com.sommelier.domain.usecase.SendPasswordResetEmailUseCase
 import br.com.sommelier.domain.usecase.SignInUserUseCase
 import br.com.sommelier.domain.usecase.SignOutUserUseCase
 import br.com.sommelier.domain.usecase.UpdateUserDocumentUseCase
+import br.com.sommelier.domain.usecase.UpdateUserEmailUseCase
 import br.com.sommelier.util.FirestoreCollections.USERS
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.ktx.auth
@@ -73,6 +74,13 @@ object SommelierModule {
         }
         factory { SignOutUserUseCase(authRepository = get(), coroutineDispatcher = get()) }
         factory { UpdateUserDocumentUseCase(userRepository = get(), coroutineDispatcher = get()) }
+        factory {
+            UpdateUserEmailUseCase(
+                authRepository = get(),
+                userRepository = get(),
+                coroutineDispatcher = get()
+            )
+        }
     }
 
     private fun provideFirebaseAuth(): FirebaseAuth {

--- a/app/src/main/java/br/com/sommelier/di/SommelierModule.kt
+++ b/app/src/main/java/br/com/sommelier/di/SommelierModule.kt
@@ -8,6 +8,7 @@ import br.com.sommelier.domain.usecase.GetCurrentUserUseCase
 import br.com.sommelier.domain.usecase.GetUserDocumentUseCase
 import br.com.sommelier.domain.usecase.IsUserEmailVerifiedUseCase
 import br.com.sommelier.domain.usecase.IsUserSignedInUseCase
+import br.com.sommelier.domain.usecase.SignInUserUseCase
 import br.com.sommelier.domain.usecase.SignOutUserUseCase
 import br.com.sommelier.util.FirestoreCollections.USERS
 import com.google.firebase.auth.FirebaseAuth
@@ -35,6 +36,7 @@ object SommelierModule {
         factory { GetCurrentUserUseCase(authRepository = get(), coroutineDispatcher = get()) }
         factory { GetUserDocumentUseCase(userRepository = get(), coroutineDispatcher = get()) }
         factory { IsUserEmailVerifiedUseCase(authRepository = get(), coroutineDispatcher = get()) }
+        factory { SignInUserUseCase(authRepository = get(), coroutineDispatcher = get()) }
         factory { IsUserSignedInUseCase(authRepository = get(), coroutineDispatcher = get()) }
         factory { SignOutUserUseCase(authRepository = get(), coroutineDispatcher = get()) }
     }

--- a/app/src/main/java/br/com/sommelier/di/SommelierModule.kt
+++ b/app/src/main/java/br/com/sommelier/di/SommelierModule.kt
@@ -5,6 +5,7 @@ import br.com.sommelier.data.repository.UserRepositoryImpl
 import br.com.sommelier.domain.repository.AuthRepository
 import br.com.sommelier.domain.repository.UserRepository
 import br.com.sommelier.domain.usecase.GetCurrentUserUseCase
+import br.com.sommelier.domain.usecase.GetUserDocumentUseCase
 import br.com.sommelier.domain.usecase.IsUserEmailVerifiedUseCase
 import br.com.sommelier.domain.usecase.IsUserSignedInUseCase
 import br.com.sommelier.domain.usecase.SignOutUserUseCase
@@ -32,6 +33,7 @@ object SommelierModule {
     private val domainModule = module {
         factory { provideCoroutinesDispatcherIO() }
         factory { GetCurrentUserUseCase(authRepository = get(), coroutineDispatcher = get()) }
+        factory { GetUserDocumentUseCase(userRepository = get(), coroutineDispatcher = get()) }
         factory { IsUserEmailVerifiedUseCase(authRepository = get(), coroutineDispatcher = get()) }
         factory { IsUserSignedInUseCase(authRepository = get(), coroutineDispatcher = get()) }
         factory { SignOutUserUseCase(authRepository = get(), coroutineDispatcher = get()) }

--- a/app/src/main/java/br/com/sommelier/di/SommelierModule.kt
+++ b/app/src/main/java/br/com/sommelier/di/SommelierModule.kt
@@ -8,6 +8,7 @@ import br.com.sommelier.domain.usecase.GetCurrentUserUseCase
 import br.com.sommelier.domain.usecase.GetUserDocumentUseCase
 import br.com.sommelier.domain.usecase.IsUserEmailVerifiedUseCase
 import br.com.sommelier.domain.usecase.IsUserSignedInUseCase
+import br.com.sommelier.domain.usecase.ReauthenticateUserUseCase
 import br.com.sommelier.domain.usecase.SendEmailVerificationUseCase
 import br.com.sommelier.domain.usecase.SignInUserUseCase
 import br.com.sommelier.domain.usecase.SignOutUserUseCase
@@ -39,13 +40,13 @@ object SommelierModule {
         factory { IsUserEmailVerifiedUseCase(authRepository = get(), coroutineDispatcher = get()) }
         factory { SignInUserUseCase(authRepository = get(), coroutineDispatcher = get()) }
         factory { IsUserSignedInUseCase(authRepository = get(), coroutineDispatcher = get()) }
+        factory { ReauthenticateUserUseCase(authRepository = get(), coroutineDispatcher = get()) }
         factory {
             SendEmailVerificationUseCase(
                 authRepository = get(),
                 coroutineDispatcher = get()
             )
         }
-        factory { SignInUserUseCase(authRepository = get(), coroutineDispatcher = get()) }
         factory { SignOutUserUseCase(authRepository = get(), coroutineDispatcher = get()) }
     }
 

--- a/app/src/main/java/br/com/sommelier/di/SommelierModule.kt
+++ b/app/src/main/java/br/com/sommelier/di/SommelierModule.kt
@@ -8,6 +8,7 @@ import br.com.sommelier.domain.usecase.GetCurrentUserUseCase
 import br.com.sommelier.domain.usecase.GetUserDocumentUseCase
 import br.com.sommelier.domain.usecase.IsUserEmailVerifiedUseCase
 import br.com.sommelier.domain.usecase.IsUserSignedInUseCase
+import br.com.sommelier.domain.usecase.SendEmailVerificationUseCase
 import br.com.sommelier.domain.usecase.SignInUserUseCase
 import br.com.sommelier.domain.usecase.SignOutUserUseCase
 import br.com.sommelier.util.FirestoreCollections.USERS
@@ -36,8 +37,14 @@ object SommelierModule {
         factory { GetCurrentUserUseCase(authRepository = get(), coroutineDispatcher = get()) }
         factory { GetUserDocumentUseCase(userRepository = get(), coroutineDispatcher = get()) }
         factory { IsUserEmailVerifiedUseCase(authRepository = get(), coroutineDispatcher = get()) }
-        factory { SignInUserUseCase(authRepository = get(), coroutineDispatcher = get()) }
         factory { IsUserSignedInUseCase(authRepository = get(), coroutineDispatcher = get()) }
+        factory {
+            SendEmailVerificationUseCase(
+                authRepository = get(),
+                coroutineDispatcher = get()
+            )
+        }
+        factory { SignInUserUseCase(authRepository = get(), coroutineDispatcher = get()) }
         factory { SignOutUserUseCase(authRepository = get(), coroutineDispatcher = get()) }
     }
 

--- a/app/src/main/java/br/com/sommelier/di/SommelierModule.kt
+++ b/app/src/main/java/br/com/sommelier/di/SommelierModule.kt
@@ -4,7 +4,10 @@ import br.com.sommelier.data.repository.AuthRepositoryImpl
 import br.com.sommelier.data.repository.UserRepositoryImpl
 import br.com.sommelier.domain.repository.AuthRepository
 import br.com.sommelier.domain.repository.UserRepository
+import br.com.sommelier.domain.usecase.GetCurrentUserUseCase
 import br.com.sommelier.domain.usecase.IsUserEmailVerifiedUseCase
+import br.com.sommelier.domain.usecase.IsUserSignedInUseCase
+import br.com.sommelier.domain.usecase.SignOutUserUseCase
 import br.com.sommelier.util.FirestoreCollections.USERS
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.ktx.auth
@@ -28,7 +31,10 @@ object SommelierModule {
 
     private val domainModule = module {
         factory { provideCoroutinesDispatcherIO() }
+        factory { GetCurrentUserUseCase(authRepository = get(), coroutineDispatcher = get()) }
         factory { IsUserEmailVerifiedUseCase(authRepository = get(), coroutineDispatcher = get()) }
+        factory { IsUserSignedInUseCase(authRepository = get(), coroutineDispatcher = get()) }
+        factory { SignOutUserUseCase(authRepository = get(), coroutineDispatcher = get()) }
     }
 
     private fun provideFirebaseAuth(): FirebaseAuth {

--- a/app/src/main/java/br/com/sommelier/domain/mapper/UserMapper.kt
+++ b/app/src/main/java/br/com/sommelier/domain/mapper/UserMapper.kt
@@ -2,6 +2,9 @@ package br.com.sommelier.domain.mapper
 
 import br.com.sommelier.data.model.UserData
 import br.com.sommelier.domain.model.UserDomain
+import br.com.sommelier.domain.model.UserFirebase
+import br.com.sommelier.util.emptyString
+import com.google.firebase.auth.FirebaseUser
 
 fun UserDomain.toData() = UserData(
     email = email,
@@ -12,5 +15,10 @@ fun UserDomain.toData() = UserData(
 fun UserData.toDomain() = UserDomain(
     email = email,
     name = name,
+    uid = uid
+)
+
+fun FirebaseUser.toDomain() = UserFirebase(
+    email = email ?: emptyString(),
     uid = uid
 )

--- a/app/src/main/java/br/com/sommelier/domain/model/UserFirebase.kt
+++ b/app/src/main/java/br/com/sommelier/domain/model/UserFirebase.kt
@@ -1,0 +1,3 @@
+package br.com.sommelier.domain.model
+
+data class UserFirebase(val email: String, val uid: String)

--- a/app/src/main/java/br/com/sommelier/domain/model/UserInfo.kt
+++ b/app/src/main/java/br/com/sommelier/domain/model/UserInfo.kt
@@ -1,0 +1,3 @@
+package br.com.sommelier.domain.model
+
+data class UserInfo(val email: String, val password: String, val name: String, val uid: String)

--- a/app/src/main/java/br/com/sommelier/domain/usecase/CreateUserUseCase.kt
+++ b/app/src/main/java/br/com/sommelier/domain/usecase/CreateUserUseCase.kt
@@ -1,0 +1,25 @@
+package br.com.sommelier.domain.usecase
+
+import arrow.core.Either
+import br.com.sommelier.base.result.Problem
+import br.com.sommelier.base.usecase.UseCase
+import br.com.sommelier.domain.model.UserDomain
+import br.com.sommelier.domain.model.UserInfo
+import br.com.sommelier.domain.repository.AuthRepository
+import br.com.sommelier.domain.repository.UserRepository
+import kotlinx.coroutines.CoroutineDispatcher
+
+class CreateUserUseCase(
+    private val authRepository: AuthRepository,
+    private val userRepository: UserRepository,
+    coroutineDispatcher: CoroutineDispatcher
+) : UseCase<UserInfo, Unit>(coroutineDispatcher) {
+
+    override suspend fun execute(parameters: UserInfo): Either<Problem, Unit> {
+        val result = authRepository.registerUser(parameters.email, parameters.password)
+        if (result.isRight()) {
+            userRepository.saveUser(UserDomain(parameters.name, parameters.email, parameters.uid))
+        }
+        return result
+    }
+}

--- a/app/src/main/java/br/com/sommelier/domain/usecase/DeleteUserUseCase.kt
+++ b/app/src/main/java/br/com/sommelier/domain/usecase/DeleteUserUseCase.kt
@@ -1,0 +1,25 @@
+package br.com.sommelier.domain.usecase
+
+import arrow.core.Either
+import br.com.sommelier.base.result.Problem
+import br.com.sommelier.base.usecase.UseCase
+import br.com.sommelier.domain.repository.AuthRepository
+import br.com.sommelier.domain.repository.UserRepository
+import kotlinx.coroutines.CoroutineDispatcher
+
+class DeleteUserUseCase(
+    private val authRepository: AuthRepository,
+    private val userRepository: UserRepository,
+    coroutineDispatcher: CoroutineDispatcher
+) : UseCase<DeleteUserUseCase.Params, Unit>(coroutineDispatcher) {
+
+    override suspend fun execute(parameters: Params): Either<Problem, Unit> {
+        val result = authRepository.deleteUser()
+        if (result.isRight()) {
+            userRepository.deleteUser(parameters.userUuid)
+        }
+        return result
+    }
+
+    data class Params(val userUuid: String)
+}

--- a/app/src/main/java/br/com/sommelier/domain/usecase/GetCurrentUserUseCase.kt
+++ b/app/src/main/java/br/com/sommelier/domain/usecase/GetCurrentUserUseCase.kt
@@ -1,0 +1,23 @@
+package br.com.sommelier.domain.usecase
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import br.com.sommelier.base.result.NullUserProblem
+import br.com.sommelier.base.result.Problem
+import br.com.sommelier.base.usecase.UseCase
+import br.com.sommelier.domain.mapper.toDomain
+import br.com.sommelier.domain.model.UserFirebase
+import br.com.sommelier.domain.repository.AuthRepository
+import kotlinx.coroutines.CoroutineDispatcher
+
+class GetCurrentUserUseCase(
+    private val authRepository: AuthRepository,
+    coroutineDispatcher: CoroutineDispatcher
+) : UseCase<UseCase.None, UserFirebase>(coroutineDispatcher) {
+
+    override suspend fun execute(parameters: None): Either<Problem, UserFirebase> {
+        return authRepository.getCurrentUser().getOrNull()?.toDomain()?.right()
+            ?: NullUserProblem("Null user problem occurred").left()
+    }
+}

--- a/app/src/main/java/br/com/sommelier/domain/usecase/GetUserDocumentUseCase.kt
+++ b/app/src/main/java/br/com/sommelier/domain/usecase/GetUserDocumentUseCase.kt
@@ -1,0 +1,20 @@
+package br.com.sommelier.domain.usecase
+
+import arrow.core.Either
+import br.com.sommelier.base.result.Problem
+import br.com.sommelier.base.usecase.UseCase
+import br.com.sommelier.domain.model.UserDomain
+import br.com.sommelier.domain.repository.UserRepository
+import kotlinx.coroutines.CoroutineDispatcher
+
+class GetUserDocumentUseCase(
+    private val userRepository: UserRepository,
+    coroutineDispatcher: CoroutineDispatcher
+) : UseCase<GetUserDocumentUseCase.Params, UserDomain>(coroutineDispatcher) {
+
+    override suspend fun execute(parameters: Params): Either<Problem, UserDomain> {
+        return userRepository.getUser(parameters.userUid)
+    }
+
+    data class Params(val userUid: String)
+}

--- a/app/src/main/java/br/com/sommelier/domain/usecase/IsUserEmailVerifiedUseCase.kt
+++ b/app/src/main/java/br/com/sommelier/domain/usecase/IsUserEmailVerifiedUseCase.kt
@@ -1,0 +1,17 @@
+package br.com.sommelier.domain.usecase
+
+import arrow.core.Either
+import br.com.sommelier.base.result.Problem
+import br.com.sommelier.base.usecase.UseCase
+import br.com.sommelier.domain.repository.AuthRepository
+import kotlinx.coroutines.CoroutineDispatcher
+
+class IsUserEmailVerifiedUseCase(
+    private val authRepository: AuthRepository,
+    coroutineDispatcher: CoroutineDispatcher
+) : UseCase<UseCase.None, Boolean>(coroutineDispatcher) {
+
+    override suspend fun execute(parameters: None): Either<Problem, Boolean> {
+        return authRepository.isUserEmailVerified()
+    }
+}

--- a/app/src/main/java/br/com/sommelier/domain/usecase/IsUserSignedInUseCase.kt
+++ b/app/src/main/java/br/com/sommelier/domain/usecase/IsUserSignedInUseCase.kt
@@ -1,0 +1,18 @@
+package br.com.sommelier.domain.usecase
+
+import arrow.core.Either
+import arrow.core.right
+import br.com.sommelier.base.result.Problem
+import br.com.sommelier.base.usecase.UseCase
+import br.com.sommelier.domain.repository.AuthRepository
+import kotlinx.coroutines.CoroutineDispatcher
+
+class IsUserSignedInUseCase(
+    private val authRepository: AuthRepository,
+    coroutineDispatcher: CoroutineDispatcher
+) : UseCase<UseCase.None, Boolean>(coroutineDispatcher) {
+
+    override suspend fun execute(parameters: None): Either<Problem, Boolean> {
+        return authRepository.isUserSignedIn().right()
+    }
+}

--- a/app/src/main/java/br/com/sommelier/domain/usecase/ReauthenticateUserUseCase.kt
+++ b/app/src/main/java/br/com/sommelier/domain/usecase/ReauthenticateUserUseCase.kt
@@ -1,0 +1,22 @@
+package br.com.sommelier.domain.usecase
+
+import arrow.core.Either
+import br.com.sommelier.base.result.Problem
+import br.com.sommelier.base.usecase.UseCase
+import br.com.sommelier.domain.repository.AuthRepository
+import kotlinx.coroutines.CoroutineDispatcher
+
+class ReauthenticateUserUseCase(
+    private val authRepository: AuthRepository,
+    coroutineDispatcher: CoroutineDispatcher
+) : UseCase<ReauthenticateUserUseCase.Params, Unit>(coroutineDispatcher) {
+
+    override suspend fun execute(parameters: Params): Either<Problem, Unit> {
+        return authRepository.reauthenticateUser(
+            parameters.userEmail,
+            parameters.userPassword
+        )
+    }
+
+    data class Params(val userEmail: String, val userPassword: String)
+}

--- a/app/src/main/java/br/com/sommelier/domain/usecase/SendEmailVerificationUseCase.kt
+++ b/app/src/main/java/br/com/sommelier/domain/usecase/SendEmailVerificationUseCase.kt
@@ -1,0 +1,17 @@
+package br.com.sommelier.domain.usecase
+
+import arrow.core.Either
+import br.com.sommelier.base.result.Problem
+import br.com.sommelier.base.usecase.UseCase
+import br.com.sommelier.domain.repository.AuthRepository
+import kotlinx.coroutines.CoroutineDispatcher
+
+class SendEmailVerificationUseCase(
+    private val authRepository: AuthRepository,
+    coroutineDispatcher: CoroutineDispatcher
+) : UseCase<UseCase.None, Unit>(coroutineDispatcher) {
+
+    override suspend fun execute(parameters: None): Either<Problem, Unit> {
+        return authRepository.sendEmailVerification()
+    }
+}

--- a/app/src/main/java/br/com/sommelier/domain/usecase/SendPasswordResetEmailUseCase.kt
+++ b/app/src/main/java/br/com/sommelier/domain/usecase/SendPasswordResetEmailUseCase.kt
@@ -1,0 +1,19 @@
+package br.com.sommelier.domain.usecase
+
+import arrow.core.Either
+import br.com.sommelier.base.result.Problem
+import br.com.sommelier.base.usecase.UseCase
+import br.com.sommelier.domain.repository.AuthRepository
+import kotlinx.coroutines.CoroutineDispatcher
+
+class SendPasswordResetEmailUseCase(
+    private val authRepository: AuthRepository,
+    coroutineDispatcher: CoroutineDispatcher
+) : UseCase<SendPasswordResetEmailUseCase.Params, Unit>(coroutineDispatcher) {
+
+    override suspend fun execute(parameters: Params): Either<Problem, Unit> {
+        return authRepository.sendPasswordResetEmail(parameters.userEmail)
+    }
+
+    data class Params(val userEmail: String)
+}

--- a/app/src/main/java/br/com/sommelier/domain/usecase/SignInUserUseCase.kt
+++ b/app/src/main/java/br/com/sommelier/domain/usecase/SignInUserUseCase.kt
@@ -1,0 +1,19 @@
+package br.com.sommelier.domain.usecase
+
+import arrow.core.Either
+import br.com.sommelier.base.result.Problem
+import br.com.sommelier.base.usecase.UseCase
+import br.com.sommelier.domain.repository.AuthRepository
+import kotlinx.coroutines.CoroutineDispatcher
+
+class SignInUserUseCase(
+    private val authRepository: AuthRepository,
+    coroutineDispatcher: CoroutineDispatcher
+) : UseCase<SignInUserUseCase.Params, Unit>(coroutineDispatcher) {
+
+    override suspend fun execute(parameters: Params): Either<Problem, Unit> {
+        return authRepository.signInUser(parameters.userEmail, parameters.userPassword)
+    }
+
+    data class Params(val userEmail: String, val userPassword: String)
+}

--- a/app/src/main/java/br/com/sommelier/domain/usecase/SignOutUserUseCase.kt
+++ b/app/src/main/java/br/com/sommelier/domain/usecase/SignOutUserUseCase.kt
@@ -1,0 +1,17 @@
+package br.com.sommelier.domain.usecase
+
+import arrow.core.Either
+import br.com.sommelier.base.result.Problem
+import br.com.sommelier.base.usecase.UseCase
+import br.com.sommelier.domain.repository.AuthRepository
+import kotlinx.coroutines.CoroutineDispatcher
+
+class SignOutUserUseCase(
+    private val authRepository: AuthRepository,
+    coroutineDispatcher: CoroutineDispatcher
+) : UseCase<UseCase.None, Unit>(coroutineDispatcher) {
+
+    override suspend fun execute(parameters: None): Either<Problem, Unit> {
+        return authRepository.signOutUser()
+    }
+}

--- a/app/src/main/java/br/com/sommelier/domain/usecase/UpdateUserDocumentUseCase.kt
+++ b/app/src/main/java/br/com/sommelier/domain/usecase/UpdateUserDocumentUseCase.kt
@@ -1,0 +1,19 @@
+package br.com.sommelier.domain.usecase
+
+import arrow.core.Either
+import br.com.sommelier.base.result.Problem
+import br.com.sommelier.base.usecase.UseCase
+import br.com.sommelier.domain.model.UserDomain
+import br.com.sommelier.domain.repository.UserRepository
+import kotlinx.coroutines.CoroutineDispatcher
+
+
+class UpdateUserDocumentUseCase(
+    private val userRepository: UserRepository,
+    coroutineDispatcher: CoroutineDispatcher
+) : UseCase<UserDomain, Unit>(coroutineDispatcher) {
+
+    override suspend fun execute(parameters: UserDomain): Either<Problem, Unit> {
+        return userRepository.updateUser(parameters)
+    }
+}

--- a/app/src/main/java/br/com/sommelier/domain/usecase/UpdateUserEmailUseCase.kt
+++ b/app/src/main/java/br/com/sommelier/domain/usecase/UpdateUserEmailUseCase.kt
@@ -1,0 +1,24 @@
+package br.com.sommelier.domain.usecase
+
+import arrow.core.Either
+import br.com.sommelier.base.result.Problem
+import br.com.sommelier.base.usecase.UseCase
+import br.com.sommelier.domain.model.UserDomain
+import br.com.sommelier.domain.repository.AuthRepository
+import br.com.sommelier.domain.repository.UserRepository
+import kotlinx.coroutines.CoroutineDispatcher
+
+class UpdateUserEmailUseCase(
+    private val authRepository: AuthRepository,
+    private val userRepository: UserRepository,
+    coroutineDispatcher: CoroutineDispatcher
+) : UseCase<UserDomain, Unit>(coroutineDispatcher) {
+
+    override suspend fun execute(parameters: UserDomain): Either<Problem, Unit> {
+        val result = authRepository.updateUserEmail(parameters.email)
+        if (result.isRight()) {
+            userRepository.updateUser(parameters)
+        }
+        return result
+    }
+}

--- a/app/src/main/java/br/com/sommelier/domain/usecase/UpdateUserPasswordUseCase.kt
+++ b/app/src/main/java/br/com/sommelier/domain/usecase/UpdateUserPasswordUseCase.kt
@@ -1,0 +1,19 @@
+package br.com.sommelier.domain.usecase
+
+import arrow.core.Either
+import br.com.sommelier.base.result.Problem
+import br.com.sommelier.base.usecase.UseCase
+import br.com.sommelier.domain.repository.AuthRepository
+import kotlinx.coroutines.CoroutineDispatcher
+
+class UpdateUserPasswordUseCase(
+    private val authRepository: AuthRepository,
+    coroutineDispatcher: CoroutineDispatcher
+) : UseCase<UpdateUserPasswordUseCase.Params, Unit>(coroutineDispatcher) {
+
+    override suspend fun execute(parameters: Params): Either<Problem, Unit> {
+        return authRepository.updateUserPassword(parameters.userPassword)
+    }
+
+    data class Params(val userPassword: String)
+}

--- a/app/src/main/java/br/com/sommelier/util/StringUtil.kt
+++ b/app/src/main/java/br/com/sommelier/util/StringUtil.kt
@@ -1,0 +1,3 @@
+package br.com.sommelier.util
+
+fun emptyString() = ""

--- a/app/src/test/java/br/com/sommelier/base/usecase/UseCaseTest.kt
+++ b/app/src/test/java/br/com/sommelier/base/usecase/UseCaseTest.kt
@@ -14,11 +14,11 @@ import org.junit.Test
 @ExperimentalCoroutinesApi
 class UseCaseTest {
 
-    private val coroutinesDispatcher = StandardTestDispatcher()
+    private val coroutineDispatcher = StandardTestDispatcher()
 
     @Test
     fun `GIVEN use case completes normally WHEN get result THEN must return the expected success result`() =
-        runTest(coroutinesDispatcher) {
+        runTest(coroutineDispatcher) {
             val successResult: Either<Problem, Boolean> = true.right()
 
             val useCase = givenUseCase<Boolean, Boolean> { successResult }
@@ -32,7 +32,7 @@ class UseCaseTest {
 
     @Test
     fun `GIVEN use case completes normally but with failure WHEN get result THEN must return the expected failure result`() =
-        runTest(coroutinesDispatcher) {
+        runTest(coroutineDispatcher) {
             val failureResult: Either<Problem, Boolean> = GenericProblem("error").left()
 
             val useCase = givenUseCase<Boolean, Boolean> { failureResult }
@@ -46,7 +46,7 @@ class UseCaseTest {
 
     @Test
     fun `GIVEn use case throws an exception WHEN get result THEN must the return the expected failure result`() =
-        runTest(coroutinesDispatcher) {
+        runTest(coroutineDispatcher) {
             val useCase = givenUseCase<Boolean, Boolean> { throw Exception("error") }
 
             val output = useCase(false)
@@ -58,7 +58,7 @@ class UseCaseTest {
 
     @Test
     fun `GIVEn use case throws an exception with null message WHEN get result THEN must the return the expected failure result`() =
-        runTest(coroutinesDispatcher) {
+        runTest(coroutineDispatcher) {
             val useCase = givenUseCase<Boolean, Boolean> { throw Exception() }
 
             val output = useCase(false)
@@ -70,7 +70,7 @@ class UseCaseTest {
         }
 
     private fun <P, R> givenUseCase(executeFunction: suspend (P) -> Either<Problem, R>): UseCase<P, R> {
-        return object : UseCase<P, R>(coroutinesDispatcher) {
+        return object : UseCase<P, R>(coroutineDispatcher) {
             override suspend fun execute(parameters: P): Either<Problem, R> {
                 return executeFunction(parameters).let { result ->
                     when (result) {

--- a/app/src/test/java/br/com/sommelier/domain/mapper/UserMapperTest.kt
+++ b/app/src/test/java/br/com/sommelier/domain/mapper/UserMapperTest.kt
@@ -4,6 +4,10 @@ import br.com.sommelier.data.model.UserData
 import br.com.sommelier.domain.mapper.toData
 import br.com.sommelier.domain.mapper.toDomain
 import br.com.sommelier.domain.model.UserDomain
+import br.com.sommelier.domain.model.UserFirebase
+import com.google.firebase.auth.FirebaseUser
+import io.mockk.every
+import io.mockk.mockk
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -31,5 +35,19 @@ class UserMapperTest {
         assertEquals(expectedUserData.email, actualUserData.email)
         assertEquals(expectedUserData.name, actualUserData.name)
         assertEquals(expectedUserData.uid, actualUserData.uid)
+    }
+
+    @Test
+    fun `GIVEN an FirebaseUser WHEN toDomain is called THEN must return the expected UserFirebase`() {
+        val firebaseUser = mockk<FirebaseUser>().apply {
+            every { email } returns "email"
+            every { uid } returns "uid"
+        }
+
+        val expectedUserFirebase = UserFirebase(email = "email", uid = "uid")
+        val actualUserFirebase = firebaseUser.toDomain()
+
+        assertEquals(expectedUserFirebase.email, actualUserFirebase.email)
+        assertEquals(expectedUserFirebase.uid, actualUserFirebase.uid)
     }
 }

--- a/app/src/test/java/br/com/sommelier/domain/mapper/UserMapperTest.kt
+++ b/app/src/test/java/br/com/sommelier/domain/mapper/UserMapperTest.kt
@@ -1,4 +1,4 @@
-package br.com.sommelier.domain
+package br.com.sommelier.domain.mapper
 
 import br.com.sommelier.data.model.UserData
 import br.com.sommelier.domain.mapper.toData

--- a/app/src/test/java/br/com/sommelier/domain/usecase/CreateUserUseCaseTest.kt
+++ b/app/src/test/java/br/com/sommelier/domain/usecase/CreateUserUseCaseTest.kt
@@ -1,0 +1,122 @@
+package br.com.sommelier.domain.usecase
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import br.com.sommelier.base.result.GenericProblem
+import br.com.sommelier.base.result.Problem
+import br.com.sommelier.base.result.RegisterUserProblem
+import br.com.sommelier.domain.model.UserInfo
+import br.com.sommelier.domain.repository.AuthRepository
+import br.com.sommelier.domain.repository.UserRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class CreateUserUseCaseTest {
+
+    private val authRepository = mockk<AuthRepository>()
+
+    private val userRepository = mockk<UserRepository>()
+
+    private val coroutineDispatcher = StandardTestDispatcher()
+
+    private lateinit var useCase: CreateUserUseCase
+
+    private val dummyUserInfo = UserInfo("email", "password", "name", "uid")
+
+    @Before
+    fun setUp() {
+        useCase = CreateUserUseCase(authRepository, userRepository, coroutineDispatcher)
+    }
+
+    @Test
+    fun `GIVEN a successful result in register a user WHEN execute use case THEN assert that saveUser was called`() =
+        runTest(coroutineDispatcher) {
+            val successfulResult: Either<Problem, Unit> = Unit.right()
+
+            coEvery { authRepository.registerUser(any(), any()) } returns successfulResult
+
+            useCase(dummyUserInfo)
+
+            coVerify(exactly = 1) {
+                userRepository.saveUser(any())
+            }
+        }
+
+    @Test
+    fun `GIVEN an unsuccessful result in register a user WHEN execute use case THEN assert that saveUser was not called`() =
+        runTest(coroutineDispatcher) {
+            val unsuccessfulResult: Either<Problem, Unit> =
+                RegisterUserProblem("Register user problem occurred").left()
+
+            coEvery { authRepository.registerUser(any(), any()) } returns unsuccessfulResult
+
+            useCase(dummyUserInfo)
+
+            coVerify(exactly = 0) {
+                userRepository.saveUser(any())
+            }
+        }
+
+    @Test
+    fun `GIVEN a successful result in register a user and a successful result in save a user WHEN execute use case THEN must return Unit`() =
+        runTest(coroutineDispatcher) {
+            val registerSuccessfulResult: Either<Problem, Unit> = Unit.right()
+
+            val saveSuccessfulResult: Either<Problem, Unit> = Unit.right()
+
+            coEvery { authRepository.registerUser(any(), any()) } returns registerSuccessfulResult
+
+            coEvery { userRepository.saveUser(any()) } returns saveSuccessfulResult
+
+            val output = useCase(dummyUserInfo)
+
+            assertTrue(output.isRight {
+                it.data == Unit
+            })
+        }
+
+    @Test
+    fun `GIVEN a successful result in register a user and an unsuccessful result in save a user WHEN execute use case THEN must return Unit`() =
+        runTest(coroutineDispatcher) {
+            val registerSuccessfulResult: Either<Problem, Unit> = Unit.right()
+
+            val saveUnsuccessfulResult: Either<Problem, Unit> =
+                GenericProblem("Generic problem occurred").left()
+
+            coEvery { authRepository.registerUser(any(), any()) } returns registerSuccessfulResult
+
+            coEvery { userRepository.saveUser(any()) } returns saveUnsuccessfulResult
+
+            val output = useCase(dummyUserInfo)
+
+            assertTrue(output.isRight {
+                it.data == Unit
+            })
+        }
+
+    @Test
+    fun `GIVEN an unsuccessful result in register a user WHEN execute use case THEN must return the expected failure result`() =
+        runTest(coroutineDispatcher) {
+            val errorMessage = "Generic problem occurred"
+            val unsuccessfulResult: Either<Problem, Unit> = GenericProblem(errorMessage).left()
+
+            coEvery { authRepository.registerUser(any(), any()) } returns unsuccessfulResult
+
+            val output = useCase(dummyUserInfo)
+
+            assertTrue(output.isLeft {
+                it.problem is GenericProblem &&
+                        (it.problem as GenericProblem).message == errorMessage
+            })
+        }
+
+}

--- a/app/src/test/java/br/com/sommelier/domain/usecase/DeleteUserUseCaseTest.kt
+++ b/app/src/test/java/br/com/sommelier/domain/usecase/DeleteUserUseCaseTest.kt
@@ -1,0 +1,117 @@
+package br.com.sommelier.domain.usecase
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import br.com.sommelier.base.result.GenericProblem
+import br.com.sommelier.base.result.Problem
+import br.com.sommelier.domain.repository.AuthRepository
+import br.com.sommelier.domain.repository.UserRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class DeleteUserUseCaseTest {
+
+    private val authRepository = mockk<AuthRepository>()
+
+    private val userRepository = mockk<UserRepository>()
+
+    private val coroutineDispatcher = StandardTestDispatcher()
+
+    private lateinit var useCase: DeleteUserUseCase
+
+    private val dummyUid = "uid"
+
+    @Before
+    fun setUp() {
+        useCase = DeleteUserUseCase(authRepository, userRepository, coroutineDispatcher)
+    }
+
+    @Test
+    fun `GIVEN a successful result in deleting user auth WHEN execute use case THEN assert that delete user doc was called`() =
+        runTest(coroutineDispatcher) {
+            val deleteUserAuthSuccessfulResult: Either<Problem, Unit> = Unit.right()
+
+            coEvery { authRepository.deleteUser() } returns deleteUserAuthSuccessfulResult
+
+            useCase(DeleteUserUseCase.Params(dummyUid))
+
+            coVerify(exactly = 1) { userRepository.deleteUser(dummyUid) }
+        }
+
+    @Test
+    fun `GIVEN an unsuccessful result in deleting user auth WHEN execute use case THEN assert that delete user doc was not called`() =
+        runTest(coroutineDispatcher) {
+            val deleteUserAuthUnsuccessfulResult: Either<Problem, Unit> =
+                GenericProblem("Generic problem occurred").left()
+
+            coEvery { authRepository.deleteUser() } returns deleteUserAuthUnsuccessfulResult
+
+            useCase(DeleteUserUseCase.Params(dummyUid))
+
+            coVerify(exactly = 0) { userRepository.deleteUser(dummyUid) }
+        }
+
+    @Test
+    fun `GIVEN a successful result in deleting user auth and a successful result in deleting user doc WHEN execute use case THEN must return Unit`() =
+        runTest(coroutineDispatcher) {
+            val deleteUserAuthSuccessfulResult: Either<Problem, Unit> = Unit.right()
+
+            val deleteUserDocSuccessfulResult: Either<Problem, Unit> = Unit.right()
+
+            coEvery { authRepository.deleteUser() } returns deleteUserAuthSuccessfulResult
+
+            coEvery { userRepository.deleteUser(dummyUid) } returns deleteUserDocSuccessfulResult
+
+            val output = useCase(DeleteUserUseCase.Params(dummyUid))
+
+            assertTrue(output.isRight {
+                it.data == Unit
+            })
+        }
+
+    @Test
+    fun `GIVEN a successful result in deleting user auth and an unsuccessful result in deleting user doc WHEN execute use case THEN must return Unit`() =
+        runTest(coroutineDispatcher) {
+            val deleteUserAuthSuccessfulResult: Either<Problem, Unit> = Unit.right()
+
+            val deleteUserDocUnsuccessfulResult: Either<Problem, Unit> = GenericProblem(
+                "Generic problem occurred"
+            ).left()
+
+            coEvery { authRepository.deleteUser() } returns deleteUserAuthSuccessfulResult
+
+            coEvery { userRepository.deleteUser(dummyUid) } returns deleteUserDocUnsuccessfulResult
+
+            val output = useCase(DeleteUserUseCase.Params(dummyUid))
+
+            assertTrue(output.isRight {
+                it.data == Unit
+            })
+        }
+
+    @Test
+    fun `GIVEN an unsuccessful result in deleting user auth WHEN execute use case THEN must return the expected failure result`() =
+        runTest(coroutineDispatcher) {
+            val errorMessage = "Generic problem occurred"
+            val deleteUserAuthUnSuccessfulResult: Either<Problem, Unit> =
+                GenericProblem(errorMessage).left()
+
+            coEvery { authRepository.deleteUser() } returns deleteUserAuthUnSuccessfulResult
+
+            val output = useCase(DeleteUserUseCase.Params(dummyUid))
+
+            assertTrue(output.isLeft {
+                it.problem is GenericProblem &&
+                        (it.problem as GenericProblem).message == errorMessage
+            })
+        }
+}

--- a/app/src/test/java/br/com/sommelier/domain/usecase/GetCurrentUserUseCaseTest.kt
+++ b/app/src/test/java/br/com/sommelier/domain/usecase/GetCurrentUserUseCaseTest.kt
@@ -1,0 +1,67 @@
+package br.com.sommelier.domain.usecase
+
+import arrow.core.Either
+import arrow.core.right
+import br.com.sommelier.base.result.NullUserProblem
+import br.com.sommelier.base.result.Problem
+import br.com.sommelier.base.usecase.UseCase
+import br.com.sommelier.domain.repository.AuthRepository
+import com.google.firebase.auth.FirebaseUser
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class GetCurrentUserUseCaseTest {
+
+    private val authRepository = mockk<AuthRepository>()
+
+    private val coroutinesDispatcher = StandardTestDispatcher()
+
+    private lateinit var useCase: GetCurrentUserUseCase
+
+    @Before
+    fun setUp() {
+        useCase = GetCurrentUserUseCase(authRepository, coroutinesDispatcher)
+    }
+
+    @Test
+    fun `GIVEN a successful result and non-null user WHEN execute use case THEN must return the expected user`() =
+        runTest(coroutinesDispatcher) {
+            val firebaseUser = mockk<FirebaseUser>().apply {
+                every { email } returns "email"
+                every { uid } returns "uid"
+            }
+
+            val successfulResult: Either<Problem, FirebaseUser> = firebaseUser.right()
+
+            every { authRepository.getCurrentUser() } returns successfulResult
+
+            val output = useCase(UseCase.None())
+
+            assertTrue(output.isRight {
+                it.data.email == firebaseUser.email && it.data.uid == firebaseUser.uid
+            })
+        }
+
+    @Test
+    fun `GIVEN a successful result and null user WHEN execute use case THEN must return the expected failure result`() =
+        runTest(coroutinesDispatcher) {
+            val nullFirebaseUser = null
+            val errorMessage = "Null user problem occurred"
+
+            every { authRepository.getCurrentUser().getOrNull() } returns nullFirebaseUser
+
+            val output = useCase(UseCase.None())
+
+            assertTrue(output.isLeft {
+                it.problem is NullUserProblem
+                        && (it.problem as NullUserProblem).message == errorMessage
+            })
+        }
+}

--- a/app/src/test/java/br/com/sommelier/domain/usecase/GetCurrentUserUseCaseTest.kt
+++ b/app/src/test/java/br/com/sommelier/domain/usecase/GetCurrentUserUseCaseTest.kt
@@ -21,18 +21,18 @@ class GetCurrentUserUseCaseTest {
 
     private val authRepository = mockk<AuthRepository>()
 
-    private val coroutinesDispatcher = StandardTestDispatcher()
+    private val coroutineDispatcher = StandardTestDispatcher()
 
     private lateinit var useCase: GetCurrentUserUseCase
 
     @Before
     fun setUp() {
-        useCase = GetCurrentUserUseCase(authRepository, coroutinesDispatcher)
+        useCase = GetCurrentUserUseCase(authRepository, coroutineDispatcher)
     }
 
     @Test
     fun `GIVEN a successful result and non-null user WHEN execute use case THEN must return the expected user`() =
-        runTest(coroutinesDispatcher) {
+        runTest(coroutineDispatcher) {
             val firebaseUser = mockk<FirebaseUser>().apply {
                 every { email } returns "email"
                 every { uid } returns "uid"
@@ -51,7 +51,7 @@ class GetCurrentUserUseCaseTest {
 
     @Test
     fun `GIVEN a successful result and null user WHEN execute use case THEN must return the expected failure result`() =
-        runTest(coroutinesDispatcher) {
+        runTest(coroutineDispatcher) {
             val nullFirebaseUser = null
             val errorMessage = "Null user problem occurred"
 

--- a/app/src/test/java/br/com/sommelier/domain/usecase/GetUserDocumentUseCaseTest.kt
+++ b/app/src/test/java/br/com/sommelier/domain/usecase/GetUserDocumentUseCaseTest.kt
@@ -1,0 +1,65 @@
+package br.com.sommelier.domain.usecase
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import br.com.sommelier.base.result.GenericProblem
+import br.com.sommelier.base.result.Problem
+import br.com.sommelier.domain.model.UserDomain
+import br.com.sommelier.domain.repository.UserRepository
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertTrue
+
+@ExperimentalCoroutinesApi
+class GetUserDocumentUseCaseTest {
+
+    private val userRepository = mockk<UserRepository>()
+
+    private val coroutinesDispatcher = StandardTestDispatcher()
+
+    private lateinit var useCase: GetUserDocumentUseCase
+
+    @Before
+    fun setUp() {
+        useCase = GetUserDocumentUseCase(userRepository, coroutinesDispatcher)
+    }
+
+    @Test
+    fun `GIVEN  a successful result WHEN execute use case THEN return the expected user`() =
+        runTest(coroutinesDispatcher) {
+            val expectedUser = UserDomain("email", "name", "uid")
+            val successfulResult: Either<Problem, UserDomain> = expectedUser.right()
+
+            coEvery { userRepository.getUser(any()) } returns successfulResult
+
+            val output = useCase(GetUserDocumentUseCase.Params(expectedUser.uid))
+
+            assertTrue(output.isRight {
+                it.data.email == expectedUser.email
+                        && it.data.name == expectedUser.name
+                        && it.data.uid == expectedUser.uid
+            })
+        }
+
+    @Test
+    fun `GIVEN  an unsuccessful result WHEN execute use case THEN return the expected failure result`() =
+        runTest(coroutinesDispatcher) {
+            val errorMessage = "Generic problem occurred"
+
+            coEvery { userRepository.getUser(any()) } returns GenericProblem(errorMessage).left()
+
+            val output = useCase(GetUserDocumentUseCase.Params("uid"))
+
+            assertTrue(output.isLeft {
+                it.problem is GenericProblem
+                        && (it.problem as GenericProblem).message == errorMessage
+            })
+        }
+
+}

--- a/app/src/test/java/br/com/sommelier/domain/usecase/GetUserDocumentUseCaseTest.kt
+++ b/app/src/test/java/br/com/sommelier/domain/usecase/GetUserDocumentUseCaseTest.kt
@@ -21,18 +21,18 @@ class GetUserDocumentUseCaseTest {
 
     private val userRepository = mockk<UserRepository>()
 
-    private val coroutinesDispatcher = StandardTestDispatcher()
+    private val coroutineDispatcher = StandardTestDispatcher()
 
     private lateinit var useCase: GetUserDocumentUseCase
 
     @Before
     fun setUp() {
-        useCase = GetUserDocumentUseCase(userRepository, coroutinesDispatcher)
+        useCase = GetUserDocumentUseCase(userRepository, coroutineDispatcher)
     }
 
     @Test
     fun `GIVEN  a successful result WHEN execute use case THEN return the expected user`() =
-        runTest(coroutinesDispatcher) {
+        runTest(coroutineDispatcher) {
             val expectedUser = UserDomain("email", "name", "uid")
             val successfulResult: Either<Problem, UserDomain> = expectedUser.right()
 
@@ -49,7 +49,7 @@ class GetUserDocumentUseCaseTest {
 
     @Test
     fun `GIVEN  an unsuccessful result WHEN execute use case THEN return the expected failure result`() =
-        runTest(coroutinesDispatcher) {
+        runTest(coroutineDispatcher) {
             val errorMessage = "Generic problem occurred"
 
             coEvery { userRepository.getUser(any()) } returns GenericProblem(errorMessage).left()

--- a/app/src/test/java/br/com/sommelier/domain/usecase/IsUserEmailVerifiedUseCaseTest.kt
+++ b/app/src/test/java/br/com/sommelier/domain/usecase/IsUserEmailVerifiedUseCaseTest.kt
@@ -22,18 +22,18 @@ class IsUserEmailVerifiedUseCaseTest {
 
     private val authRepository = mockk<AuthRepository>()
 
-    private val coroutinesDispatcher = StandardTestDispatcher()
+    private val coroutineDispatcher = StandardTestDispatcher()
 
     private lateinit var useCase: IsUserEmailVerifiedUseCase
 
     @Before
     fun setUp() {
-        useCase = IsUserEmailVerifiedUseCase(authRepository, coroutinesDispatcher)
+        useCase = IsUserEmailVerifiedUseCase(authRepository, coroutineDispatcher)
     }
 
     @Test
     fun `GIVEN a successful result and a user with verified email WHEN execute use case THEN must return true`() =
-        runTest(coroutinesDispatcher) {
+        runTest(coroutineDispatcher) {
             val isUserEmailVerified: Either<Problem, Boolean> = true.right()
 
             every { authRepository.isUserEmailVerified() } returns isUserEmailVerified
@@ -47,7 +47,7 @@ class IsUserEmailVerifiedUseCaseTest {
 
     @Test
     fun `GIVEN a successful result and a user with unverified email WHEN execute use case THEN must return false`() =
-        runTest(coroutinesDispatcher) {
+        runTest(coroutineDispatcher) {
             val isUserEmailVerified: Either<Problem, Boolean> = false.right()
 
             every { authRepository.isUserEmailVerified() } returns isUserEmailVerified
@@ -61,7 +61,7 @@ class IsUserEmailVerifiedUseCaseTest {
 
     @Test
     fun `GIVEN an unsuccessful result WHEN execute use case THEN must return the expected failure result`() =
-        runTest(coroutinesDispatcher) {
+        runTest(coroutineDispatcher) {
             val errorMessage = "Generic problem occurred"
             val problem: Either<Problem, Boolean> = GenericProblem(errorMessage).left()
 

--- a/app/src/test/java/br/com/sommelier/domain/usecase/IsUserEmailVerifiedUseCaseTest.kt
+++ b/app/src/test/java/br/com/sommelier/domain/usecase/IsUserEmailVerifiedUseCaseTest.kt
@@ -60,7 +60,7 @@ class IsUserEmailVerifiedUseCaseTest {
         }
 
     @Test
-    fun `GIVEN a unsuccessful result WHEN execute use case THEN must return the expected failure result`() =
+    fun `GIVEN an unsuccessful result WHEN execute use case THEN must return the expected failure result`() =
         runTest(coroutinesDispatcher) {
             val errorMessage = "Generic problem occurred"
             val problem: Either<Problem, Boolean> = GenericProblem(errorMessage).left()

--- a/app/src/test/java/br/com/sommelier/domain/usecase/IsUserEmailVerifiedUseCaseTest.kt
+++ b/app/src/test/java/br/com/sommelier/domain/usecase/IsUserEmailVerifiedUseCaseTest.kt
@@ -1,0 +1,77 @@
+package br.com.sommelier.domain.usecase
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import br.com.sommelier.base.result.GenericProblem
+import br.com.sommelier.base.result.Problem
+import br.com.sommelier.base.usecase.UseCase
+import br.com.sommelier.domain.repository.AuthRepository
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class IsUserEmailVerifiedUseCaseTest {
+
+    private val authRepository = mockk<AuthRepository>()
+
+    private val coroutinesDispatcher = StandardTestDispatcher()
+
+    private lateinit var useCase: IsUserEmailVerifiedUseCase
+
+    @Before
+    fun setUp() {
+        useCase = IsUserEmailVerifiedUseCase(authRepository, coroutinesDispatcher)
+    }
+
+    @Test
+    fun `GIVEN a successful result and a user with verified email WHEN execute use case THEN must return true`() =
+        runTest(coroutinesDispatcher) {
+            val isUserEmailVerified: Either<Problem, Boolean> = true.right()
+
+            every { authRepository.isUserEmailVerified() } returns isUserEmailVerified
+
+            val result = useCase(UseCase.None())
+
+            assertTrue(result.isRight {
+                it.data
+            })
+        }
+
+    @Test
+    fun `GIVEN a successful result and a user with unverified email WHEN execute use case THEN must return false`() =
+        runTest(coroutinesDispatcher) {
+            val isUserEmailVerified: Either<Problem, Boolean> = false.right()
+
+            every { authRepository.isUserEmailVerified() } returns isUserEmailVerified
+
+            val result = useCase(UseCase.None())
+
+            assertFalse(result.isRight {
+                it.data
+            })
+        }
+
+    @Test
+    fun `GIVEN a unsuccessful result WHEN execute use case THEN must return the expected failure result`() =
+        runTest(coroutinesDispatcher) {
+            val errorMessage = "Generic problem occurred"
+            val problem: Either<Problem, Boolean> = GenericProblem(errorMessage).left()
+
+            every { authRepository.isUserEmailVerified() } returns problem
+
+            val result = useCase(UseCase.None())
+
+            assertTrue(result.isLeft {
+                it.problem is GenericProblem
+                        && (it.problem as GenericProblem).message == errorMessage
+            })
+        }
+}

--- a/app/src/test/java/br/com/sommelier/domain/usecase/IsUserSignedInUseCaseTest.kt
+++ b/app/src/test/java/br/com/sommelier/domain/usecase/IsUserSignedInUseCaseTest.kt
@@ -1,0 +1,52 @@
+package br.com.sommelier.domain.usecase
+
+import br.com.sommelier.base.usecase.UseCase
+import br.com.sommelier.domain.repository.AuthRepository
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class IsUserSignedInUseCaseTest {
+
+    private val authRepository = mockk<AuthRepository>()
+
+    private val coroutinesDispatcher = StandardTestDispatcher()
+
+    private lateinit var useCase: IsUserSignedInUseCase
+
+    @Before
+    fun setUp() {
+        useCase = IsUserSignedInUseCase(authRepository, coroutinesDispatcher)
+    }
+
+    @Test
+    fun `GIVEN a signed in user WHEN execute use case THEN must return true`() =
+        runTest(coroutinesDispatcher) {
+            val isUserSignedIn = true
+
+            every { authRepository.isUserSignedIn() } returns isUserSignedIn
+
+            val result = useCase(UseCase.None())
+
+            assertTrue(result.isRight { it.data })
+        }
+
+    @Test
+    fun `GIVEN a not signed in user WHEN execute use case THEN must return true`() =
+        runTest(coroutinesDispatcher) {
+            val isUserSignedIn = false
+
+            every { authRepository.isUserSignedIn() } returns isUserSignedIn
+
+            val result = useCase(UseCase.None())
+
+            assertFalse(result.isRight { it.data })
+        }
+}

--- a/app/src/test/java/br/com/sommelier/domain/usecase/IsUserSignedInUseCaseTest.kt
+++ b/app/src/test/java/br/com/sommelier/domain/usecase/IsUserSignedInUseCaseTest.kt
@@ -17,18 +17,18 @@ class IsUserSignedInUseCaseTest {
 
     private val authRepository = mockk<AuthRepository>()
 
-    private val coroutinesDispatcher = StandardTestDispatcher()
+    private val coroutineDispatcher = StandardTestDispatcher()
 
     private lateinit var useCase: IsUserSignedInUseCase
 
     @Before
     fun setUp() {
-        useCase = IsUserSignedInUseCase(authRepository, coroutinesDispatcher)
+        useCase = IsUserSignedInUseCase(authRepository, coroutineDispatcher)
     }
 
     @Test
     fun `GIVEN a signed in user WHEN execute use case THEN must return true`() =
-        runTest(coroutinesDispatcher) {
+        runTest(coroutineDispatcher) {
             val isUserSignedIn = true
 
             every { authRepository.isUserSignedIn() } returns isUserSignedIn
@@ -40,7 +40,7 @@ class IsUserSignedInUseCaseTest {
 
     @Test
     fun `GIVEN a not signed in user WHEN execute use case THEN must return true`() =
-        runTest(coroutinesDispatcher) {
+        runTest(coroutineDispatcher) {
             val isUserSignedIn = false
 
             every { authRepository.isUserSignedIn() } returns isUserSignedIn

--- a/app/src/test/java/br/com/sommelier/domain/usecase/ReauthenticateUserUseCaseTest.kt
+++ b/app/src/test/java/br/com/sommelier/domain/usecase/ReauthenticateUserUseCaseTest.kt
@@ -5,7 +5,6 @@ import arrow.core.left
 import arrow.core.right
 import br.com.sommelier.base.result.GenericProblem
 import br.com.sommelier.base.result.Problem
-import br.com.sommelier.base.usecase.UseCase
 import br.com.sommelier.domain.repository.AuthRepository
 import io.mockk.coEvery
 import io.mockk.mockk
@@ -17,17 +16,21 @@ import org.junit.Before
 import org.junit.Test
 
 @ExperimentalCoroutinesApi
-class SendEmailVerificationUseCaseTest {
+class ReauthenticateUserUseCaseTest {
 
     private val authRepository = mockk<AuthRepository>()
 
     private val coroutineDispatcher = StandardTestDispatcher()
 
-    private lateinit var useCase: SendEmailVerificationUseCase
+    private lateinit var useCase: ReauthenticateUserUseCase
+
+    private val dummyEmail = "email"
+
+    private val dummyPassword = "password"
 
     @Before
     fun setUp() {
-        useCase = SendEmailVerificationUseCase(
+        useCase = ReauthenticateUserUseCase(
             authRepository = authRepository,
             coroutineDispatcher = coroutineDispatcher
         )
@@ -38,9 +41,14 @@ class SendEmailVerificationUseCaseTest {
         runTest(coroutineDispatcher) {
             val successfulResult: Either<Problem, Unit> = Unit.right()
 
-            coEvery { authRepository.sendEmailVerification() } returns successfulResult
+            coEvery {
+                authRepository.reauthenticateUser(
+                    dummyEmail,
+                    dummyPassword
+                )
+            } returns successfulResult
 
-            val output = useCase(UseCase.None())
+            val output = useCase(ReauthenticateUserUseCase.Params(dummyEmail, dummyPassword))
 
             assertTrue(output.isRight {
                 it.data == Unit
@@ -53,13 +61,17 @@ class SendEmailVerificationUseCaseTest {
             val errorMessage = "Generic problem occurred"
             val unsuccessfulResult: Either<Problem, Unit> = GenericProblem(errorMessage).left()
 
-            coEvery { authRepository.sendEmailVerification() } returns unsuccessfulResult
+            coEvery {
+                authRepository.reauthenticateUser(
+                    dummyEmail,
+                    dummyPassword
+                )
+            } returns unsuccessfulResult
 
-            val output = useCase(UseCase.None())
+            val output = useCase(ReauthenticateUserUseCase.Params(dummyEmail, dummyPassword))
 
             assertTrue(output.isLeft {
-                it.problem is GenericProblem
-                        && (it.problem as GenericProblem).message == errorMessage
+                it.problem is GenericProblem && (it.problem as GenericProblem).message == errorMessage
             })
         }
 }

--- a/app/src/test/java/br/com/sommelier/domain/usecase/SendEmailVerificationUseCaseTest.kt
+++ b/app/src/test/java/br/com/sommelier/domain/usecase/SendEmailVerificationUseCaseTest.kt
@@ -1,0 +1,65 @@
+package br.com.sommelier.domain.usecase
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import br.com.sommelier.base.result.GenericProblem
+import br.com.sommelier.base.result.Problem
+import br.com.sommelier.base.usecase.UseCase
+import br.com.sommelier.domain.repository.AuthRepository
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class SendEmailVerificationUseCaseTest {
+
+    private val authRepository = mockk<AuthRepository>()
+
+    private val coroutineDispatcher = StandardTestDispatcher()
+
+    private lateinit var useCase: SendEmailVerificationUseCase
+
+    @Before
+    fun setUp() {
+        useCase = SendEmailVerificationUseCase(
+            authRepository = authRepository,
+            coroutineDispatcher = coroutineDispatcher
+        )
+    }
+
+    @Test
+    fun `GIVEN a successful result WHEN execute use case THEN must return Unit`() =
+        runTest(coroutineDispatcher) {
+            val successfulResult: Either<Problem, Unit> = Unit.right()
+
+            coEvery { authRepository.sendEmailVerification() } returns successfulResult
+
+            val output = useCase(UseCase.None())
+
+            assertTrue(output.isRight {
+                it.data == Unit
+            })
+        }
+
+    @Test
+    fun `GIVEN a unsuccessful result WHEN execute use case THEN must return failure result`() =
+        runTest(coroutineDispatcher) {
+            val errorMessage = "Generic problem occurred"
+            val unsuccessfulResult: Either<Problem, Unit> = GenericProblem(errorMessage).left()
+
+            coEvery { authRepository.sendEmailVerification() } returns unsuccessfulResult
+
+            val output = useCase(UseCase.None())
+
+            assertTrue(output.isLeft {
+                it.problem is GenericProblem
+                        && (it.problem as GenericProblem).message == errorMessage
+            })
+        }
+}

--- a/app/src/test/java/br/com/sommelier/domain/usecase/SendPasswordResetEmailUseCaseTest.kt
+++ b/app/src/test/java/br/com/sommelier/domain/usecase/SendPasswordResetEmailUseCaseTest.kt
@@ -1,0 +1,67 @@
+package br.com.sommelier.domain.usecase
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import br.com.sommelier.base.result.GenericProblem
+import br.com.sommelier.base.result.Problem
+import br.com.sommelier.base.usecase.UseCase
+import br.com.sommelier.domain.repository.AuthRepository
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class SendPasswordResetEmailUseCaseTest {
+
+    private val authRepository = mockk<AuthRepository>()
+
+    private val coroutineDispatcher = StandardTestDispatcher()
+
+    private lateinit var useCase: SendPasswordResetEmailUseCase
+
+    private val dummyEmail = "dummyEmail"
+
+    @Before
+    fun setUp() {
+        useCase = SendPasswordResetEmailUseCase(
+            authRepository = authRepository,
+            coroutineDispatcher = coroutineDispatcher
+        )
+    }
+
+    @Test
+    fun `GIVEN a successful result WHEN execute use case THEN must return Unit`() =
+        runTest(coroutineDispatcher) {
+            val successfulResult: Either<Problem, Unit> = Unit.right()
+
+            coEvery { authRepository.sendPasswordResetEmail(any()) } returns successfulResult
+
+            val output = useCase(SendPasswordResetEmailUseCase.Params(dummyEmail))
+
+            assertTrue(output.isRight {
+                it.data == Unit
+            })
+        }
+
+    @Test
+    fun `GIVEN an unsuccessful result WHEN execute use case THEN must return the expected failure`() =
+        runTest(coroutineDispatcher) {
+            val errorMessage = "Generic problem occurred"
+            val unsuccessfulResult: Either<Problem, Unit> = GenericProblem(errorMessage).left()
+
+            coEvery { authRepository.sendPasswordResetEmail(any()) } returns unsuccessfulResult
+
+            val output = useCase(SendPasswordResetEmailUseCase.Params(dummyEmail))
+
+            assertTrue(output.isLeft {
+                it.problem is GenericProblem
+                        && (it.problem as GenericProblem).message == errorMessage
+            })
+        }
+}

--- a/app/src/test/java/br/com/sommelier/domain/usecase/SignInUserUseCaseTest.kt
+++ b/app/src/test/java/br/com/sommelier/domain/usecase/SignInUserUseCaseTest.kt
@@ -1,0 +1,75 @@
+package br.com.sommelier.domain.usecase
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import br.com.sommelier.base.result.GenericProblem
+import br.com.sommelier.base.result.Problem
+import br.com.sommelier.domain.repository.AuthRepository
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class SignInUserUseCaseTest {
+
+    private val authRepository = mockk<AuthRepository>()
+
+    private val coroutineDispatcher = StandardTestDispatcher()
+
+    private lateinit var useCase: SignInUserUseCase
+
+    private val dummyEmail = "email"
+
+    private val dummyPassword = "password"
+
+    @Before
+    fun setUp() {
+        useCase = SignInUserUseCase(authRepository, coroutineDispatcher)
+    }
+
+    @Test
+    fun `GIVEN a successful result WHEN execute use case THEN must return Unit`() =
+        runTest(coroutineDispatcher) {
+            val successfulResult: Either<Problem, Unit> = Unit.right()
+
+            coEvery {
+                authRepository.signInUser(
+                    dummyEmail,
+                    dummyPassword
+                )
+            } returns successfulResult
+
+            val output = useCase(SignInUserUseCase.Params(dummyEmail, dummyPassword))
+
+            assertTrue(output.isRight {
+                it.data == Unit
+            })
+        }
+
+    @Test
+    fun `GIVEN an unsuccessful result WHEN execute use case THEN must return the expected failure`() =
+        runTest(coroutineDispatcher) {
+            val errorMessage = "Generic problem occurred"
+            val unsuccessfulResult: Either<Problem, Unit> = GenericProblem(errorMessage).left()
+
+            coEvery {
+                authRepository.signInUser(
+                    dummyEmail,
+                    dummyPassword
+                )
+            } returns unsuccessfulResult
+
+            val output = useCase(SignInUserUseCase.Params(dummyEmail, dummyPassword))
+
+            assertTrue(output.isLeft {
+                it.problem is GenericProblem
+                        && (it.problem as GenericProblem).message == errorMessage
+            })
+        }
+}

--- a/app/src/test/java/br/com/sommelier/domain/usecase/SignOutUserUseCaseTest.kt
+++ b/app/src/test/java/br/com/sommelier/domain/usecase/SignOutUserUseCaseTest.kt
@@ -1,7 +1,6 @@
 package br.com.sommelier.domain.usecase
 
 import arrow.core.left
-import arrow.core.prependTo
 import arrow.core.right
 import br.com.sommelier.base.result.AlreadySignedOutUserProblem
 import br.com.sommelier.base.usecase.UseCase
@@ -20,18 +19,18 @@ class SignOutUserUseCaseTest {
 
     private val authRepository = mockk<AuthRepository>()
 
-    private val coroutinesDispatcher = StandardTestDispatcher()
+    private val coroutineDispatcher = StandardTestDispatcher()
 
     private lateinit var signOutUserUseCase: SignOutUserUseCase
 
     @Before
     fun setUp() {
-        signOutUserUseCase = SignOutUserUseCase(authRepository, coroutinesDispatcher)
+        signOutUserUseCase = SignOutUserUseCase(authRepository, coroutineDispatcher)
     }
 
     @Test
     fun `GIVEN a successful result WHEN execute use case THEN must return the expected success result`() =
-        runTest(coroutinesDispatcher) {
+        runTest(coroutineDispatcher) {
             every { authRepository.signOutUser() } returns Unit.right()
 
             val output = signOutUserUseCase(UseCase.None())
@@ -43,7 +42,7 @@ class SignOutUserUseCaseTest {
 
     @Test
     fun `GIVEN an unsuccessful result WHEN execute use case THEN must return the expected failure result`() =
-        runTest(coroutinesDispatcher) {
+        runTest(coroutineDispatcher) {
             val errorMessage = "Already signed out user problem occurred"
             every {
                 authRepository.signOutUser()

--- a/app/src/test/java/br/com/sommelier/domain/usecase/SignOutUserUseCaseTest.kt
+++ b/app/src/test/java/br/com/sommelier/domain/usecase/SignOutUserUseCaseTest.kt
@@ -1,0 +1,60 @@
+package br.com.sommelier.domain.usecase
+
+import arrow.core.left
+import arrow.core.prependTo
+import arrow.core.right
+import br.com.sommelier.base.result.AlreadySignedOutUserProblem
+import br.com.sommelier.base.usecase.UseCase
+import br.com.sommelier.domain.repository.AuthRepository
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class SignOutUserUseCaseTest {
+
+    private val authRepository = mockk<AuthRepository>()
+
+    private val coroutinesDispatcher = StandardTestDispatcher()
+
+    private lateinit var signOutUserUseCase: SignOutUserUseCase
+
+    @Before
+    fun setUp() {
+        signOutUserUseCase = SignOutUserUseCase(authRepository, coroutinesDispatcher)
+    }
+
+    @Test
+    fun `GIVEN a successful result WHEN execute use case THEN must return the expected success result`() =
+        runTest(coroutinesDispatcher) {
+            every { authRepository.signOutUser() } returns Unit.right()
+
+            val output = signOutUserUseCase(UseCase.None())
+
+            assertTrue(output.isRight {
+                it.data == Unit
+            })
+        }
+
+    @Test
+    fun `GIVEN an unsuccessful result WHEN execute use case THEN must return the expected failure result`() =
+        runTest(coroutinesDispatcher) {
+            val errorMessage = "Already signed out user problem occurred"
+            every {
+                authRepository.signOutUser()
+            } returns AlreadySignedOutUserProblem(errorMessage).left()
+
+            val output = signOutUserUseCase(UseCase.None())
+
+            assertTrue(output.isLeft() {
+                it.problem is AlreadySignedOutUserProblem
+                        && (it.problem as AlreadySignedOutUserProblem).message == errorMessage
+            })
+        }
+
+}

--- a/app/src/test/java/br/com/sommelier/domain/usecase/UpdateUserDocumentUseCaseTest.kt
+++ b/app/src/test/java/br/com/sommelier/domain/usecase/UpdateUserDocumentUseCaseTest.kt
@@ -1,0 +1,63 @@
+package br.com.sommelier.domain.usecase
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import br.com.sommelier.base.result.GenericProblem
+import br.com.sommelier.base.result.Problem
+import br.com.sommelier.domain.model.UserDomain
+import br.com.sommelier.domain.repository.UserRepository
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class UpdateUserDocumentUseCaseTest {
+
+    private val userRepository = mockk<UserRepository>()
+
+    private val coroutineDispatcher = StandardTestDispatcher()
+
+    private lateinit var useCase: UpdateUserDocumentUseCase
+
+    private val dummyUserDomain = UserDomain("email", "name", "uid")
+
+    @Before
+    fun setup() {
+        useCase = UpdateUserDocumentUseCase(userRepository, coroutineDispatcher)
+    }
+
+    @Test
+    fun `GIVEN a successful result WHEN execute use case THEN must return Unit`() =
+        runTest(coroutineDispatcher) {
+            val successfulResult: Either<Problem, Unit> = Unit.right()
+
+            coEvery { userRepository.updateUser(dummyUserDomain) } returns successfulResult
+
+            val output = useCase(dummyUserDomain)
+
+            assertTrue(output.isRight {
+                it.data == Unit
+            })
+        }
+
+    @Test
+    fun `GIVEN an unsuccessful result WHEN execute use case THEN must return failure result`() =
+        runTest(coroutineDispatcher) {
+            val errorMessage = "Generic problem occurred"
+            val unsuccessfulResult: Either<Problem, Unit> = GenericProblem(errorMessage).left()
+
+            coEvery { userRepository.updateUser(dummyUserDomain) } returns unsuccessfulResult
+
+            val output = useCase(dummyUserDomain)
+
+            assertTrue(output.isLeft {
+                it.problem is GenericProblem && (it.problem as GenericProblem).message == errorMessage
+            })
+        }
+}

--- a/app/src/test/java/br/com/sommelier/domain/usecase/UpdateUserEmailUseCaseTest.kt
+++ b/app/src/test/java/br/com/sommelier/domain/usecase/UpdateUserEmailUseCaseTest.kt
@@ -1,0 +1,134 @@
+package br.com.sommelier.domain.usecase
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import br.com.sommelier.base.result.GenericProblem
+import br.com.sommelier.base.result.Problem
+import br.com.sommelier.domain.model.UserDomain
+import br.com.sommelier.domain.repository.AuthRepository
+import br.com.sommelier.domain.repository.UserRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class UpdateUserEmailUseCaseTest {
+
+    private val authRepository = mockk<AuthRepository>()
+
+    private val userRepository = mockk<UserRepository>()
+
+    private val coroutineDispatcher = StandardTestDispatcher()
+
+    private lateinit var useCase: UpdateUserEmailUseCase
+
+    private val dummyUserDomain = UserDomain("email", "name", "uid")
+
+    @Before
+    fun setUp() {
+        useCase = UpdateUserEmailUseCase(authRepository, userRepository, coroutineDispatcher)
+    }
+
+    @Test
+    fun `GIVEN a successful result in updating user email WHEN execute use case THEN assert that updateUser was called`() =
+        runTest(coroutineDispatcher) {
+            val updateUserEmailResult: Either<Problem, Unit> = Unit.right()
+
+            coEvery {
+                authRepository.updateUserEmail(dummyUserDomain.email)
+            } returns updateUserEmailResult
+
+            useCase(dummyUserDomain)
+
+            coVerify(exactly = 1) {
+                userRepository.updateUser(dummyUserDomain)
+            }
+        }
+
+    @Test
+    fun `GIVEN a unsuccessful result in updating user email WHEN execute use case THEN assert that updateUser was not called`() =
+        runTest(coroutineDispatcher) {
+            val updateUserEmailResult: Either<Problem, Unit> =
+                GenericProblem("Generic problem occurred").left()
+
+            coEvery {
+                authRepository.updateUserEmail(dummyUserDomain.email)
+            } returns updateUserEmailResult
+
+            useCase(dummyUserDomain)
+
+            coVerify(exactly = 0) {
+                userRepository.updateUser(dummyUserDomain)
+            }
+        }
+
+    @Test
+    fun `GIVEN a successful result in updating user email and a successful result in updating user doc WHEN execute use case THEN must return Unit`() =
+        runTest(coroutineDispatcher) {
+            val updateUserEmailResult: Either<Problem, Unit> = Unit.right()
+
+            val updateUserResult: Either<Problem, Unit> = Unit.right()
+
+            coEvery {
+                authRepository.updateUserEmail(dummyUserDomain.email)
+            } returns updateUserEmailResult
+
+            coEvery {
+                userRepository.updateUser(dummyUserDomain)
+            } returns updateUserResult
+
+            val output = useCase(dummyUserDomain)
+
+            assertTrue(output.isRight {
+                it.data == Unit
+            })
+        }
+
+    @Test
+    fun `GIVEN a successful result in updating user email and an unsuccessful result in updating user doc WHEN execute use case THEN must return Unit`() =
+        runTest(coroutineDispatcher) {
+            val updateUserEmailResult: Either<Problem, Unit> = Unit.right()
+
+            val updateUserResult: Either<Problem, Unit> =
+                GenericProblem("Generic problem occurred").left()
+
+            coEvery {
+                authRepository.updateUserEmail(dummyUserDomain.email)
+            } returns updateUserEmailResult
+
+            coEvery {
+                userRepository.updateUser(dummyUserDomain)
+            } returns updateUserResult
+
+            val output = useCase(dummyUserDomain)
+
+            assertTrue(output.isRight {
+                it.data == Unit
+            })
+        }
+
+    @Test
+    fun `GIVEN an unsuccessful result in updating user email WHEN execute use case THEN must return the expected failure`() =
+        runTest(coroutineDispatcher) {
+            val updateUserEmailResult: Either<Problem, Unit> =
+                GenericProblem("Generic problem occurred").left()
+
+            coEvery {
+                authRepository.updateUserEmail(dummyUserDomain.email)
+            } returns updateUserEmailResult
+
+            val output = useCase(dummyUserDomain)
+
+            assertTrue(output.isLeft {
+                it.problem is GenericProblem &&
+                        (it.problem as GenericProblem).message == "Generic problem occurred"
+            })
+        }
+}

--- a/app/src/test/java/br/com/sommelier/domain/usecase/UpdateUserPasswordUseCaseTest.kt
+++ b/app/src/test/java/br/com/sommelier/domain/usecase/UpdateUserPasswordUseCaseTest.kt
@@ -1,0 +1,63 @@
+package br.com.sommelier.domain.usecase
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import br.com.sommelier.base.result.GenericProblem
+import br.com.sommelier.base.result.Problem
+import br.com.sommelier.domain.repository.AuthRepository
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class UpdateUserPasswordUseCaseTest {
+
+    private val authRepository = mockk<AuthRepository>()
+
+    private val coroutineDispatcher = StandardTestDispatcher()
+
+    private lateinit var useCase: UpdateUserPasswordUseCase
+
+    private val dummyPassword = "password"
+
+    @Before
+    fun setUp() {
+        useCase = UpdateUserPasswordUseCase(authRepository, coroutineDispatcher)
+    }
+
+    @Test
+    fun `GIVEN a successful result WHEN execute use case THEN must return Unit`() =
+        runTest(coroutineDispatcher) {
+            val result: Either<Problem, Unit> = Unit.right()
+
+            coEvery { authRepository.updateUserPassword(dummyPassword) } returns result
+
+            val output = useCase(UpdateUserPasswordUseCase.Params(dummyPassword))
+
+            assertTrue(output.isRight {
+                it.data == Unit
+            })
+        }
+
+    @Test
+    fun `GIVEN an unsuccessful result WHEN execute use case THEN must return the expected failure`() =
+        runTest(coroutineDispatcher) {
+            val errorMessage = "Generic problem occurred"
+            val result: Either<Problem, Unit> = GenericProblem(errorMessage).left()
+
+            coEvery { authRepository.updateUserPassword(dummyPassword) } returns result
+
+            val output = useCase(UpdateUserPasswordUseCase.Params(dummyPassword))
+
+            assertTrue(output.isLeft {
+                it.problem is GenericProblem &&
+                        (it.problem as GenericProblem).message == errorMessage
+            })
+        }
+}


### PR DESCRIPTION
### This Pull Request includes
- [ ] Bugfix

- [x] New feature

- [x] Refactor

### Summary
This Pull Request implements all user-related use cases.

### Changes
- Added `CreateUserUseCase`
- Added `GetCurrentUserUseCase`
- Added `DeleteUserUseCase`
- Added `GetUserDocumentUseCase`
- Added `IsUserEmailVerifiedUseCase`
- Added `IsUserSignedInUseCase`
- Added `ReauthenticateUserUseCase`
- Added `SendEmailVerificationUseCase`
- Added `SendPasswordResetEmailUseCase`
- Added `SignInUserUseCase`
- Added `SignOutUserUseCase`
- Added `UpdateUserDocumentUseCase`
- Added `UpdateUserEmailUseCase`
- Added `UpdateUserPasswordUseCase`
- Creat unit test for all these use cases
- Injected all these use cases into Sommelier's domain module
- Introduced two new data classes: UserFirebase for Firebase useful information and UserInfo for user-related information
- Corrected the spelling of "coroutines" to "coroutine"
- Implemented a new utility function: emptyString(), which returns an empty string

### Related Issues
N/A

### Screenshots (if applicable)
N/A

### Feature flags
N/A

### Impact
Sommlier's domain module

### Tests
Uni tests

### Additional Notes
N/A

### Reviewers
- @ronaldocoding 

