### PR TITLE
Set up jacoco

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,6 +26,9 @@ android {
     }
 
     buildTypes {
+        debug {
+            enableUnitTestCoverage true
+        }
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
@@ -48,6 +51,9 @@ android {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
+    }
+    jacoco {
+        version "0.8.10"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,4 +4,36 @@ plugins {
     id 'com.android.library' version '8.0.2' apply false
     id 'org.jetbrains.kotlin.android' version '1.7.20' apply false
     id 'com.google.gms.google-services' version '4.3.15' apply false
+    id 'jacoco' apply true
+}
+
+tasks.create(name: "unitTestCoverageReport", type: JacocoReport, dependsOn: "testLocalDebugUnitTest") {
+    group = "Verification" // existing group containing tasks for generating linting reports etc.
+    description = "Generate Jacoco coverage reports for the 'local' debug build."
+
+    reports {
+        // human readable (written into './build/reports/jacoco/unitTestCoverageReport/html')
+        html {
+            enabled true
+        }
+        // CI-readable (written into './build/reports/jacoco/unitTestCoverageReport/unitTestCoverageReport.xml')
+        xml {
+            enabled true
+        }
+    }
+
+    // Execution data generated when running the tests against classes instrumented by the JaCoCo agent.
+    // This is enabled with 'enableUnitTestCoverage' in the 'debug' build type.
+    executionData.from = "${project.buildDir}/outputs/unit_test_code_coverage/localDebugUnitTest/testLocalDebugUnitTest.exec"
+
+    // Compiled Kotlin class files are written into build-variant-specific subdirectories of 'build/tmp/kotlin-classes'.
+    classDirectories.from = "${project.buildDir}/tmp/kotlin-classes/localDebug"
+
+    // To produce an accurate report, the bytecode is mapped back to the original source code.
+    sourceDirectories.from = "${project.projectDir}/src/main/java"
+}
+
+tasks.withType(Test) {
+    jacoco.includeNoLocationClasses true
+    jacoco.excludes = ['jdk.internal.*']
 }


### PR DESCRIPTION
### This Pull Request includes
- [ ] Bugfix

- [x] New feature

- [ ] Refactor

### Summary
This Pull Request introduces Jacoco (Java Code Coverage Library) to the project. Jacoco is a free code coverage library for Java, created by the EclEmma team, incorporating lessons learned from using and integrating existing libraries over many years. 

### Changes
- Set up Jacoco in the gradle project at both the project-level and top-level.

### Related Issues
N/A

### Screenshots (if applicable)
| Tests result    | Test coverage |
| -------- | ------- |
| <img width="1097" alt="Screen Shot 2023-07-23 at 23 07 27" src="https://github.com/ronaldocoding/sommelier/assets/42837154/aad8fcde-7a58-4eac-8401-6be2d57a050b"> |  <img width="1097" alt="Screen Shot 2023-07-23 at 23 07 42" src="https://github.com/ronaldocoding/sommelier/assets/42837154/8fc30f8d-c92d-4bff-86e9-22a301a91162">  |

### Feature flags
N/A

### Impact
Entire application

### Tests
N/A

### Additional Notes
N/A

### Reviewers
- @ronaldocoding 

