### PR TITLE
Add quick action button

### DIFF
--- a/.idea/androidTestResultsUserPreferences.xml
+++ b/.idea/androidTestResultsUserPreferences.xml
@@ -42,7 +42,33 @@
             </AndroidTestResultsTableState>
           </value>
         </entry>
+        <entry key="-470475233">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_1080x1920" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
         <entry key="1241373120">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_1080x1920" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="1773113059">
           <value>
             <AndroidTestResultsTableState>
               <option name="preferredColumnWidths">

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,41 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="PreviewAnnotationInFunctionWithParameters" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewApiLevelMustBeValid" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewFontScaleMustBeGreaterThanZero" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewMultipleParameterProviders" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewNotSupportedInUnitTestFiles" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewPickerAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+  </profile>
+</component>

--- a/app/src/androidTest/java/br/com/sommelier/ui/component/QuickActionButtonTest.kt
+++ b/app/src/androidTest/java/br/com/sommelier/ui/component/QuickActionButtonTest.kt
@@ -1,0 +1,37 @@
+package br.com.sommelier.ui.component
+
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.printToLog
+import org.junit.Rule
+import org.junit.Test
+
+class QuickActionButtonTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun givenQuickActionDefaultProperties_WhenRendered_ThenShouldAssertDefaultState() {
+        composeTestRule.setContent {
+            QuickActionButton()
+        }
+        composeTestRule.onNodeWithTag("QuickActionButton")
+            .assertIsDisplayed()
+            .assertHasClickAction()
+        composeTestRule.onNodeWithTag("QuickActionButtonIcon", useUnmergedTree = true)
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun givenQuickActionDefaultProperties_WhenRendered_ThenPerformClick() {
+        composeTestRule.setContent {
+            QuickActionButton()
+        }
+        composeTestRule.onNodeWithTag("QuickActionButton").performClick()
+    }
+}

--- a/app/src/androidTest/java/br/com/sommelier/ui/component/QuickActionButtonTest.kt
+++ b/app/src/androidTest/java/br/com/sommelier/ui/component/QuickActionButtonTest.kt
@@ -4,9 +4,7 @@ import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.printToLog
 import org.junit.Rule
 import org.junit.Test
 

--- a/app/src/main/java/br/com/sommelier/presentation/MainActivity.kt
+++ b/app/src/main/java/br/com/sommelier/presentation/MainActivity.kt
@@ -3,14 +3,19 @@ package br.com.sommelier.presentation
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import br.com.sommelier.ui.component.ActionButton
+import br.com.sommelier.ui.component.QuickActionButton
 import br.com.sommelier.ui.theme.SommelierTheme
 import br.com.sommelier.ui.theme.Spacing
 
@@ -23,11 +28,17 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    ActionButton(
-                        text = "Login",
-                        onClick = {},
-                        modifier = Modifier.padding(horizontal = Spacing.small)
-                    )
+                    Column(
+                        verticalArrangement = Arrangement.Center,
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        ActionButton(
+                            text = "Login",
+                            modifier = Modifier.padding(horizontal = Spacing.small)
+                        )
+                        Spacer(modifier = Modifier.padding(Spacing.small))
+                        QuickActionButton()
+                    }
                 }
             }
         }
@@ -42,11 +53,17 @@ fun SommelierPreview() {
             modifier = Modifier.fillMaxSize(),
             color = MaterialTheme.colorScheme.background
         ) {
-            ActionButton(
-                text = "Login",
-                onClick = { /*TODO*/ },
-                modifier = Modifier.padding(horizontal = Spacing.mediumLarge)
-            )
+            Column(
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                ActionButton(
+                    text = "Login",
+                    modifier = Modifier.padding(horizontal = Spacing.small)
+                )
+                Spacer(modifier = Modifier.padding(Spacing.small))
+                QuickActionButton()
+            }
         }
     }
 }

--- a/app/src/main/java/br/com/sommelier/ui/component/QuickActionButton.kt
+++ b/app/src/main/java/br/com/sommelier/ui/component/QuickActionButton.kt
@@ -1,0 +1,53 @@
+package br.com.sommelier.ui.component
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.tooling.preview.Preview
+import br.com.sommelier.ui.theme.ColorReference
+import br.com.sommelier.ui.theme.Sizing
+
+@Composable
+fun QuickActionButton(
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit = {},
+    backgroundColor: Color = ColorReference.royalPurple,
+    iconImage: ImageVector = Icons.Default.Add,
+    iconColor: Color = ColorReference.white,
+    contentDescription: String? = null
+) {
+    FloatingActionButton(
+        onClick = onClick,
+        modifier = modifier
+            .shadow(
+                elevation = Sizing.small,
+                shape = RoundedCornerShape(Sizing.small),
+                clip = false
+            )
+            .testTag("QuickActionButton"),
+        shape = MaterialTheme.shapes.large,
+        containerColor = backgroundColor,
+        contentColor = iconColor
+    ) {
+        Icon(
+            iconImage,
+            contentDescription = contentDescription,
+            modifier = Modifier.testTag("QuickActionButtonIcon")
+        )
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+fun QuickActionButtonDefaultPreview() {
+    QuickActionButton()
+}


### PR DESCRIPTION
### This Pull Request includes
- [ ] Bugfix

- [x] New feature

- [ ] Refactor

### Summary
This Pull Request introduces a new component called `QuickActionButton` to the project.

`QuickActionButton` is a rounded rectangular button designed to execute quick actions, such as opening a screen.

### Changes
- Created the `QuickActionButton` component and its corresponding tests.

### Related Issues
N/A

### Screenshots (if applicable)
![main_activity](https://github.com/ronaldocoding/sommelier/assets/42837154/cf31f1f7-12fd-4420-a4eb-95b51329d3b2)

### Feature flags
N/A

### Impact
The `QuickActionButton` component currently impacts only the MainActivity, but it will be removed shortly.

### Tests
Tests have been implemented to cover `QuickActionButton`'s properties and states.

### Additional Notes
N/A

### Reviewers
@ronaldocoding 

### References
N/A