### PR TITLE
Fix bug of remaining error state in fields

### DIFF
--- a/app/src/main/java/br/com/sommelier/presentation/login/viewmodel/LoginViewModel.kt
+++ b/app/src/main/java/br/com/sommelier/presentation/login/viewmodel/LoginViewModel.kt
@@ -128,7 +128,7 @@ class LoginViewModel(
 
     private suspend fun handleTryToLogin() {
         val state = checkNotNull(_uiState.value)
-        val uiModel = state.uiModel
+        val uiModel = removePossibleRemainingErrorState(state.uiModel)
         signInUserUseCase(
             SignInUserUseCase.Params(
                 userEmail = uiModel.emailUiState.text,
@@ -161,6 +161,19 @@ class LoginViewModel(
                     }
                 )
             }
+        )
+    }
+
+    private fun removePossibleRemainingErrorState(uiModel: LoginUiModel): LoginUiModel {
+        return uiModel.copy(
+            emailUiState = uiModel.emailUiState.copy(
+                errorSupportingMessage = LoginStringResource.Empty,
+                isError = false
+            ),
+            passwordUiState = uiModel.passwordUiState.copy(
+                errorSupportingMessage = LoginStringResource.Empty,
+                isError = false
+            )
         )
     }
 

--- a/app/src/main/java/br/com/sommelier/presentation/register/viewmodel/RegisterViewModel.kt
+++ b/app/src/main/java/br/com/sommelier/presentation/register/viewmodel/RegisterViewModel.kt
@@ -9,6 +9,7 @@ import br.com.sommelier.domain.model.UserInfo
 import br.com.sommelier.domain.usecase.CreateUserUseCase
 import br.com.sommelier.domain.usecase.SendEmailVerificationUseCase
 import br.com.sommelier.presentation.register.action.RegisterAction
+import br.com.sommelier.presentation.register.model.RegisterUiModel
 import br.com.sommelier.presentation.register.res.RegisterStringResource
 import br.com.sommelier.presentation.register.state.RegisterUiEffect
 import br.com.sommelier.presentation.register.state.RegisterUiState
@@ -202,7 +203,7 @@ class RegisterViewModel(
 
     private suspend fun handleOnTryToRegister() {
         val state = checkNotNull(_uiState.value)
-        val uiModel = state.uiModel
+        val uiModel = removePossibleRemainingErrorState(state.uiModel)
         val userInfo = UserInfo(
             name = uiModel.nameUiState.text,
             email = uiModel.emailUiState.text,
@@ -217,6 +218,31 @@ class RegisterViewModel(
                 sendEmailVerificationUseCase(UseCase.None())
                 _uiEffect.value = RegisterUiEffect.OpenConfirmEmailScreen
             }
+        )
+    }
+
+    private fun removePossibleRemainingErrorState(uiModel: RegisterUiModel): RegisterUiModel {
+        val newNameUiState = uiModel.nameUiState.copy(
+            errorSupportingMessage = RegisterStringResource.Empty,
+            isError = false
+        )
+        val newEmailUiState = uiModel.emailUiState.copy(
+            errorSupportingMessage = RegisterStringResource.Empty,
+            isError = false
+        )
+        val newPasswordUiState = uiModel.passwordUiState.copy(
+            errorSupportingMessage = RegisterStringResource.Empty,
+            isError = false
+        )
+        val newPasswordConfirmationUiState = uiModel.passwordConfirmationUiState.copy(
+            errorSupportingMessage = RegisterStringResource.Empty,
+            isError = false
+        )
+        return uiModel.copy(
+            nameUiState = newNameUiState,
+            emailUiState = newEmailUiState,
+            passwordUiState = newPasswordUiState,
+            passwordConfirmationUiState = newPasswordConfirmationUiState
         )
     }
 }

--- a/app/src/main/java/br/com/sommelier/ui/component/OutlinedPasswordInput.kt
+++ b/app/src/main/java/br/com/sommelier/ui/component/OutlinedPasswordInput.kt
@@ -101,7 +101,7 @@ fun OutlinedPasswordInput(
             errorBorderColor = ColorReference.seaShell,
             errorCursorColor = ColorReference.bitterSweet,
             errorSupportingTextColor = ColorReference.bitterSweet,
-            errorLeadingIconColor = ColorReference.bitterSweet,
+            errorLeadingIconColor = ColorReference.bitterSweet
         ),
         shape = RoundedCornerShape(Sizing.normal),
         placeholder = {

--- a/app/src/main/java/br/com/sommelier/ui/component/OutlinedTextInput.kt
+++ b/app/src/main/java/br/com/sommelier/ui/component/OutlinedTextInput.kt
@@ -89,7 +89,7 @@ fun OutlinedTextInput(
             errorBorderColor = ColorReference.seaShell,
             errorCursorColor = ColorReference.bitterSweet,
             errorSupportingTextColor = ColorReference.bitterSweet,
-            errorLeadingIconColor = ColorReference.bitterSweet,
+            errorLeadingIconColor = ColorReference.bitterSweet
         ),
         shape = RoundedCornerShape(Sizing.normal),
         keyboardOptions = keyboardOptions,

--- a/app/src/test/java/br/com/sommelier/presentation/register/viewmodel/RegisterViewModelTest.kt
+++ b/app/src/test/java/br/com/sommelier/presentation/register/viewmodel/RegisterViewModelTest.kt
@@ -587,22 +587,22 @@ class RegisterViewModelTest {
                     nameUiState = NameUiState(
                         text = userInfo.name,
                         errorSupportingMessage = RegisterStringResource.Empty,
-                        isError = false,
+                        isError = false
                     ),
                     emailUiState = EmailUiState(
                         text = userInfo.email,
                         errorSupportingMessage = RegisterStringResource.Empty,
-                        isError = false,
+                        isError = false
                     ),
                     passwordUiState = PasswordUiState(
                         text = userInfo.password,
                         errorSupportingMessage = RegisterStringResource.Empty,
-                        isError = false,
+                        isError = false
                     ),
                     passwordConfirmationUiState = PasswordConfirmationUiState(
                         text = userInfo.password,
                         errorSupportingMessage = RegisterStringResource.Empty,
-                        isError = false,
+                        isError = false
                     )
                 )
             )


### PR DESCRIPTION
### This Pull Request includes
- [x] Bugfix

- [ ] New feature

- [ ] Refactor

### Summary
This Pull Request fixes a bug that occurred when you clicked on the enter or register buttons and the fields still had an error state.

This problem occurred because in the viewmodel, when a problem occurred, the state machine went to error and the states of all the fields remained the same. In other words, if a field was in error status before the action button was clicked, it would remain in error status if a problem occurred in the view model.

### Changes
- [ ] FIx bug in `LoginViewModel` and `RegisterViewModel`

### Related Issues
N/A

### Screenshots (if applicable)
N/A

### Feature flags
N/A

### Impact
Register and login view models

### Tests
Unit tests

### Additional Notes
N/A

### Reviewers
@ronaldocoding 

### References
N/A